### PR TITLE
flake8: ignore E203 and set max line length to 120

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
-ignore = W191,E101,E265
+ignore = W191,E101,E265,E203
+max-line-length = 120


### PR DESCRIPTION
Ignore E203 to avoid whitespace-before-':' warnings on slice
formatting such as: `a[1 : 3]`

Increase max line length to 120 chars

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>
