### PR TITLE
DEFw: libfabric transport phase 0 - transport ops seam + uuid message identity

### DIFF
--- a/src/defw_common.h
+++ b/src/defw_common.h
@@ -19,7 +19,10 @@
 #define BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */
 #define BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
 
-#define DEFW_VERSION_NUMBER		 1
+/* Bumped to 2: the message header now carries the sender uuid instead of
+ * the sender IP address. Old and new builds are intentionally incompatible.
+ */
+#define DEFW_VERSION_NUMBER		 2
 
 #define MAX_STR_LEN			1024
 #define MAX_SHORT_STR_LEN		128

--- a/src/defw_listener.c
+++ b/src/defw_listener.c
@@ -262,7 +262,6 @@ static defw_rc_t process_agent_message(defw_agent_blk_t *agent, int fd)
 	defw_message_hdr_t hdr = {0};
 	char *buffer;
 	defw_msg_process_fn_t proc_fn;
-	int cmp;
 
 	/* get the header first */
 	rc = readTcpMessage(fd, (char *)&hdr, sizeof(hdr),
@@ -278,12 +277,21 @@ static defw_rc_t process_agent_message(defw_agent_blk_t *agent, int fd)
 		return EN_DEFW_RC_BAD_VERSION;
 	}
 
-	/* if the ips don't match ignore the message */
-	hdr.ip.s_addr = ntohl(hdr.ip.s_addr);
-	if ((cmp = memcmp(&agent->addr.sin_addr, &hdr.ip, sizeof(hdr.ip)))) {
-		PERROR("IP addresses don't match");
-		PERROR("agent IP = %s", inet_ntoa(agent->addr.sin_addr));
-		PERROR("hdr IP = %s", inet_ntoa(hdr.ip));
+	/* Validate the sender identity by remote uuid. A brand new
+	 * connection has no uuid yet; it arrives in the session info, so we
+	 * trust the first message and let process_msg_session_info record
+	 * the uuid (trust on first use). Once the uuid is known, a mismatch
+	 * means the message did not come from the agent that owns this
+	 * connection and is dropped.
+	 */
+	if (!uuid_is_null(agent->id.remote_uuid) &&
+	    uuid_compare(agent->id.remote_uuid, hdr.sender_uuid)) {
+		char got[UUID_STR_LEN], expected[UUID_STR_LEN];
+
+		uuid_unparse_lower(hdr.sender_uuid, got);
+		uuid_unparse_lower(agent->id.remote_uuid, expected);
+		PERROR("sender uuid mismatch: expected %s got %s",
+		       expected, got);
 		return EN_DEFW_RC_BAD_ADDR;
 	}
 

--- a/src/defw_message.h
+++ b/src/defw_message.h
@@ -18,10 +18,15 @@ typedef enum {
 	EN_MSG_TYPE_MAX
 } defw_msg_type_t;
 
+/* The sender identity is the sender's remote uuid rather than its source
+ * IP address. A uuid is meaningful on any transport (TCP sockets, but also
+ * connectionless fabrics where there is no per-peer socket to read an
+ * address from), so this is the identity check shared by all transports.
+ */
 typedef struct defw_message_hdr_s {
 	defw_msg_type_t type;
 	unsigned int len;
-	struct in_addr ip;
+	uuid_t sender_uuid;
 	unsigned int version;
 } defw_message_hdr_t;
 

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -1,0 +1,95 @@
+#ifndef DEFW_TRANSPORT_H
+#define DEFW_TRANSPORT_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "defw_common.h"
+#include "defw_message.h"
+#include "defw_agent.h"
+
+/*
+ * DEFw transport abstraction.
+ *
+ * DEFw historically spoke TCP directly: the agent and listener code called
+ * the socket send/receive helpers by name. This ops table is the seam that
+ * lets an alternate transport (e.g. libfabric/OFI) carry the same framed
+ * messages without the agent, listener, or Python layers knowing which
+ * transport is in use.
+ *
+ * Phase 0 introduces the seam and routes the outbound framed-message path
+ * through it, with a single built-in TCP implementation that preserves the
+ * historical behavior exactly. Later phases add an OFI implementation and
+ * wire the remaining ops (endpoint init, peer connect, event-loop progress).
+ */
+
+/*
+ * Logical channel a message travels on. TCP maps these onto the agent's two
+ * sockets (control and RPC); a tagged transport such as OFI maps them onto
+ * bits in the message tag (see defw_tag_make below).
+ */
+typedef enum {
+	EN_DEFW_CHANNEL_CTRL = 0, /* session info + heartbeats */
+	EN_DEFW_CHANNEL_RPC,      /* python request / response / event */
+} defw_channel_t;
+
+/*
+ * Tag layout for tagged transports: [channel:8][msg_type:8][reserved:48].
+ * TCP does not use tags (it demultiplexes by socket and reads the framed
+ * header), but the encoding lives here so every transport shares one
+ * definition. These helpers are unused until the OFI transport lands.
+ */
+static inline uint64_t defw_tag_make(defw_channel_t ch, defw_msg_type_t type)
+{
+	return (((uint64_t)ch & 0xff) << 56) |
+	       (((uint64_t)type & 0xff) << 48);
+}
+
+static inline defw_channel_t defw_tag_channel(uint64_t tag)
+{
+	return (defw_channel_t)((tag >> 56) & 0xff);
+}
+
+static inline defw_msg_type_t defw_tag_msg_type(uint64_t tag)
+{
+	return (defw_msg_type_t)((tag >> 48) & 0xff);
+}
+
+/*
+ * Transport operations.
+ *
+ * Phase 0 exercises send(). The remaining ops are declared now to document
+ * the interface a transport must provide; they are left NULL by the TCP
+ * transport because the existing listener/connect code still owns those
+ * paths for TCP. The OFI transport will implement all of them, and the
+ * listener/connect code will be routed through init/connect/progress in a
+ * later phase.
+ */
+typedef struct defw_transport_ops_s {
+	const char *name;
+
+	/* Send a framed DEFw message to agent on the given channel. */
+	defw_rc_t (*send)(defw_agent_blk_t *agent, defw_channel_t ch,
+			  char *buf, size_t len, defw_msg_type_t type);
+
+	/* Reserved for later phases; NULL in phase 0. */
+	defw_rc_t (*init)(void *listener_info);
+	defw_rc_t (*connect)(defw_agent_blk_t *agent);
+	defw_rc_t (*progress)(void);
+	void      (*disconnect)(defw_agent_blk_t *agent);
+	void      (*fini)(void);
+} defw_transport_ops_t;
+
+/* Return the active transport ops. Defaults to the built-in TCP transport
+ * and is never NULL.
+ */
+defw_transport_ops_t *defw_transport_ops(void);
+
+/* Select the active transport. A NULL argument is ignored. Used by later
+ * phases to switch to OFI based on configuration.
+ */
+void defw_transport_set_ops(defw_transport_ops_t *ops);
+
+/* The built-in TCP transport. */
+defw_transport_ops_t *defw_transport_tcp_ops(void);
+
+#endif /* DEFW_TRANSPORT_H */

--- a/src/defw_transport_tcp.c
+++ b/src/defw_transport_tcp.c
@@ -1,0 +1,64 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include "defw_transport.h"
+#include "defw_agent.h"
+#include "libdefw_connect.h"
+#include "defw_common.h"
+#include "defw_print.h"
+
+/*
+ * Built-in TCP transport.
+ *
+ * Maps the logical CTRL and RPC channels onto the agent's two sockets and
+ * forwards to the existing framed-message writer (defw_send_msg). This keeps
+ * DEFw's historical wire behavior identical; the ops table simply names the
+ * seam that a fabric transport will later plug into.
+ */
+static defw_rc_t tcp_send(defw_agent_blk_t *agent, defw_channel_t ch,
+			  char *buf, size_t len, defw_msg_type_t type)
+{
+	int fd;
+
+	if (!agent)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	fd = (ch == EN_DEFW_CHANNEL_RPC) ? agent->iRpcFd : agent->iFileDesc;
+
+	return defw_send_msg(fd, buf, len, type);
+}
+
+static defw_transport_ops_t tcp_ops = {
+	.name = "tcp",
+	.send = tcp_send,
+	.init = NULL,
+	.connect = NULL,
+	.progress = NULL,
+	.disconnect = NULL,
+	.fini = NULL,
+};
+
+/* Statically initialized so the accessor is valid before any explicit
+ * transport setup runs.
+ */
+static defw_transport_ops_t *g_transport = &tcp_ops;
+
+defw_transport_ops_t *defw_transport_tcp_ops(void)
+{
+	return &tcp_ops;
+}
+
+defw_transport_ops_t *defw_transport_ops(void)
+{
+	return g_transport;
+}
+
+void defw_transport_set_ops(defw_transport_ops_t *ops)
+{
+	if (ops)
+		g_transport = ops;
+}

--- a/src/libdefw_agent.c
+++ b/src/libdefw_agent.c
@@ -18,6 +18,7 @@
 #include "defw_list.h"
 #include "defw_python.h"
 #include "defw_listener.h"
+#include "defw_transport.h"
 #include "defw_print.h"
 
 extern fd_set g_tAllSet;
@@ -669,8 +670,9 @@ defw_rc_t defw_send_session_info(defw_agent_blk_t *agent, bool rpc_setup)
 	msg.node_name[MAX_STR_LEN-1] = '\0';
 	gethostname(msg.node_hostname, MAX_STR_LEN);
 
-	rc = defw_send_msg((rpc_setup) ? agent->iRpcFd : agent->iFileDesc,
-			  (char *)&msg, sizeof(msg), EN_MSG_TYPE_SESSION_INFO);
+	rc = defw_transport_ops()->send(agent,
+			(rpc_setup) ? EN_DEFW_CHANNEL_RPC : EN_DEFW_CHANNEL_CTRL,
+			(char *)&msg, sizeof(msg), EN_MSG_TYPE_SESSION_INFO);
 	if (rc != EN_DEFW_RC_OK) {
 		PERROR("Failed to send heart beat %s\n",
 			defw_rc2str(rc));
@@ -696,8 +698,8 @@ defw_rc_t defw_send_hb(defw_agent_blk_t *agent)
 	//       agent->iRpcFd);
 
 	/* send the heart beat */
-	rc = defw_send_msg(agent->iFileDesc, (char *)&msg,
-			   sizeof(msg), EN_MSG_TYPE_HB);
+	rc = defw_transport_ops()->send(agent, EN_DEFW_CHANNEL_CTRL,
+			(char *)&msg, sizeof(msg), EN_MSG_TYPE_HB);
 	if (rc != EN_DEFW_RC_OK) {
 		PERROR("Failed to send heart beat %s\n",
 			defw_rc2str(rc));
@@ -969,7 +971,8 @@ defw_send(char *dst_uuid, char *blk_uuid, char *yaml, defw_msg_type_t type)
 
 	set_agent_state(agent_blk, DEFW_AGENT_WORK_IN_PROGRESS);
 
-	rc = defw_send_msg(agent_blk->iRpcFd, yaml, msg_size, type);
+	rc = defw_transport_ops()->send(agent_blk, EN_DEFW_CHANNEL_RPC,
+			yaml, msg_size, type);
 	if (rc != EN_DEFW_RC_OK) {
 		PERROR("Failed to send rpc message: %s", yaml);
 		goto fail_rpc;

--- a/src/libdefw_connect.c
+++ b/src/libdefw_connect.c
@@ -14,8 +14,10 @@
 #include <strings.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
+#include <uuid/uuid.h>
 #include "defw_print.h"
 #include "libdefw_connect.h"
+#include "defw.h"
 
 static defw_rc_t doNonBlockingConnect(int iSockFd, struct sockaddr *psSA,
 				      int iSAlen, int iNsec)
@@ -204,9 +206,6 @@ defw_rc_t populateMsgHdr(int rsocket, char *msg_hdr,
 			 int defw_version_number)
 {
 	defw_message_hdr_t *hdr = NULL;
-	struct sockaddr_in sock;
-	int len = sizeof(sock);
-	int rc;
 
 	if (rsocket == INVALID_TCP_SOCKET ||
 	    msg_hdr == NULL) {
@@ -217,19 +216,13 @@ defw_rc_t populateMsgHdr(int rsocket, char *msg_hdr,
 
 	hdr = (defw_message_hdr_t *)msg_hdr;
 
-	/* get the local IP address we are connected on */
-	rc = getsockname(rsocket,
-			(struct sockaddr *)&sock,
-			(socklen_t *)&len);
-	if (rc) {
-		PERROR("getsockname failure %s:%s:%d",
-		       strerror(errno), strerror(rc), rc);
-		return EN_DEFW_RC_FAIL;
-	}
-
 	hdr->type = htonl(msg_type);
 	hdr->len = htonl(msg_size);
-	hdr->ip.s_addr = htonl(sock.sin_addr.s_addr);
+	/* Stamp the sender identity: our own remote uuid. This replaces the
+	 * previous source-IP stamp and is valid regardless of transport.
+	 * uuid_t is a byte array, so no endian conversion is needed.
+	 */
+	uuid_copy(hdr->sender_uuid, g_defw_cfg.uuid);
 	hdr->version = htonl(defw_version_number);
 
 	return EN_DEFW_RC_OK;


### PR DESCRIPTION
## Summary

Phase 0 of the libfabric transport effort (design:
[openQSE/QFw#27](https://github.com/openQSE/QFw/pull/27)). This lays the
groundwork inside DEFw for a libfabric/OFI transport **without** adding
libfabric yet. TCP behavior is unchanged; the goal is to establish the seam
and the transport-neutral message identity that the OFI transport (phase 1)
will build on.

Two self-contained commits:

### 1. Identify message senders by uuid instead of ip

The message header stamped the sender's source IPv4 address, and the receiver
validated a message by comparing that address to the connection's peer
address. A source IP is a TCP-specific notion with no meaning on a
connectionless fabric. This replaces the header IP field with the sender's
remote uuid (which every agent already owns), validated against the agent
block — trust-on-first-use for a brand new connection (the uuid is learned
from the session info that arrives on it), reject mismatches thereafter.

**Wire-format change**: `DEFW_VERSION_NUMBER` is bumped to 2; old and new
builds are intentionally incompatible.

### 2. Route framed sends through a transport ops table

Introduces `defw_transport.h` — a small ops table (`send` now; endpoint
`init`/`connect`/`progress` reserved for later phases) plus a shared
channel/tag encoding — and `defw_transport_tcp.c`, a built-in TCP
implementation that maps the CTRL/RPC channels onto the agent's two sockets
and forwards to the existing writer. The three framed-send sites (heartbeat,
session info, RPC) in `libdefw_agent.c` now go through
`defw_transport_ops()->send()`. The active transport defaults to TCP and is
never NULL.

The new TCP source is a non-`libdefw*` file, so the SConstruct glob folds it
into `libfwsl.so` with no build-script change.

## Testing

Built and verified in the QFw-SLURM-Cluster container (Rocky 10): rebuilt
DEFw from this branch with `qfw_build.sh --defw` and ran
`examples/qfw_mpi_smoke.sh`. Clean pass — two MPI ranks plus the service
process report `"status": "ok"` with a clean setup/teardown, and none of the
failure modes these changes could introduce (`version 1 != 2` mismatch or
`sender uuid mismatch`) appear.

Because phase 0 is deliberately behavior-neutral, a passing smoke test alone
doesn't prove the new code was exercised, so this was confirmed directly: the
rebuilt `src/libfwsl.so` contains the new `defw_transport_ops` /
`defw_transport_tcp_ops` / `defw_transport_set_ops` symbols, i.e. the RPC path
is going through the ops seam.

Phase 0's exit criterion — existing tests/examples pass unchanged — is met.
(The change cannot be built natively on macOS, which lacks
`pthread_spinlock`/`UUID_STR_LEN`; that is a pre-existing gap affecting the
whole codebase identically, not specific to this PR.)

## Scope notes

- The lazy RPC-channel establishment and the raw `sendTcpMessage` in
  `process_msg_get_num_agents` remain TCP-specific for now; they move behind
  the `connect`/`progress` ops in phase 1 when OFI needs them.
- No libfabric dependency is introduced by this PR.
