### PR TITLE
DEFw: libfabric (OFI) transport — phases 0+1 (supersedes #14)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,10 +52,11 @@ def build_shared_library(env):
 
 def mbuild_shared_library(env, files, so):
     print("building shared library from ", " ".join(files))
-    cmd = env['CC'] + " " + env['SWIG_COMP_FLAGS'] + \
+    cmd = env['CC'] + " " + env['SWIG_COMP_FLAGS'] + " " + \
+            env.get('LIBFABRIC_CFLAGS', '') + \
             " -I" + env['PYTHON_INCLUDE_DIR'] + \
             " -fPIC -shared -luuid -o " + so + " " + \
-            " ".join(files)
+            " ".join(files) + " " + env.get('LIBFABRIC_LIBS', '')
     print(cmd)
     os.system(cmd)
 
@@ -162,6 +163,44 @@ def install(env, src, dst):
     #os.system(cmd)
     return
 
+def detect_libfabric(env):
+    """Locate libfabric so the OFI transport can be built.
+
+    Prefer pkg-config (libfabric ships a .pc; the QFw container puts it on
+    PKG_CONFIG_PATH). Fall back to LIBFABRIC_DIR / LIBFABRIC_INSTALL_DIR. When
+    libfabric is not found, DEFw builds TCP-only: defw_transport_ofi.c still
+    compiles, but only its stub (no HAVE_LIBFABRIC), so there is no new hard
+    dependency for existing users.
+    """
+    import subprocess
+    cflags = libs = ''
+    have = False
+    try:
+        subprocess.check_call(['pkg-config', '--exists', 'libfabric'])
+        cflags = subprocess.check_output(
+            ['pkg-config', '--cflags', 'libfabric'], text=True).strip()
+        libs = subprocess.check_output(
+            ['pkg-config', '--libs', 'libfabric'], text=True).strip()
+        have = True
+    except Exception:
+        prefix = os.environ.get('LIBFABRIC_DIR') or \
+                 os.environ.get('LIBFABRIC_INSTALL_DIR')
+        if prefix and os.path.exists(
+                os.path.join(prefix, 'include', 'rdma', 'fabric.h')):
+            cflags = "-I" + os.path.join(prefix, 'include')
+            libs = "-L" + os.path.join(prefix, 'lib') + " -lfabric"
+            have = True
+
+    if have:
+        cflags = (cflags + " -DHAVE_LIBFABRIC").strip()
+        print("libfabric: found -> " + cflags + " " + libs)
+    else:
+        print("libfabric: not found (building TCP-only transport)")
+
+    env['LIBFABRIC_CFLAGS'] = cflags
+    env['LIBFABRIC_LIBS'] = libs
+    env['HAVE_LIBFABRIC'] = have
+
 def build_bin(env):
     binary = env['DEFW_MAIN_C']
     path = os.path.join(env['DEFW_PATH'], "src", "defwp")
@@ -171,6 +210,7 @@ def build_bin(env):
             " -I" + env['PYTHON_INCLUDE_DIR'] + " " + \
             binary + " -L" + env['LINK_PATH'] + " -L" + env['PYTHON_LIB_DIR'] + \
             " -lfwsl -ldefw_global -ldefw_connect -ldefw_agent -luuid -l" + env['PYTHON_LIB'] + \
+            " " + env.get('LIBFABRIC_LIBS', '') + \
             " -o " + path
     print(cmd)
     os.system(cmd)
@@ -228,6 +268,8 @@ env['PYTHON_INCLUDE_DIR'] = sysconfig.get_config_var('INCLUDEPY')
 env['PYTHON_LIB_DIR'] = sysconfig.get_config_var('LIBDIR')
 env['PYTHON_LIB'] = os.path.splitext(sysconfig.get_config_var('LDLIBRARY').strip('lib'))[0]
 env['DEFW_MAIN_C'] = os.path.join(DEFW_PATH, 'src', 'defw.c')
+
+detect_libfabric(env)
 
 env.AddMethod(generate_swig_intf)
 env.AddMethod(swigify)

--- a/src/defw_agent.h
+++ b/src/defw_agent.h
@@ -1,6 +1,7 @@
 #ifndef DEFW_AGENTS_H
 #define DEFW_AGENTS_H
 
+#include <stdint.h>
 #include "defw_common.h"
 #include "defw_message.h"
 
@@ -13,6 +14,10 @@
 #define DEFW_AGENT_WORK_IN_PROGRESS (1 << 3)
 #define DEFW_AGENT_STATE_DEAD (1 << 4)
 #define DEFW_AGENT_STATE_NEW (1 << 5)
+/* set once the peer's OFI address has been inserted into the address vector
+ * and cached in ofi_addr below
+ */
+#define DEFW_AGENT_OFI_ADDR_VALID (1 << 6)
 
 #ifndef DLIST_ENTRY
 #define DLIST_ENTRY
@@ -44,6 +49,11 @@ typedef struct defw_agent_blk_s {
 	unsigned int ref_count;
 	defw_type_t node_type;
 	char *rpc_response;
+	/* peer's fi_addr_t (stored as uint64_t so this transport-agnostic
+	 * header needs no libfabric include); valid only when the
+	 * DEFW_AGENT_OFI_ADDR_VALID state bit is set
+	 */
+	uint64_t ofi_addr;
 } defw_agent_blk_t;
 
 /* agent_state2str

--- a/src/defw_common.h
+++ b/src/defw_common.h
@@ -20,9 +20,13 @@
 #define BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
 
 /* Bumped to 2: the message header now carries the sender uuid instead of
- * the sender IP address. Old and new builds are intentionally incompatible.
+ * the sender IP address.
+ * Bumped to 3: the session message now carries the sender's OFI endpoint
+ * address, so its size changed. Old and new builds are intentionally
+ * incompatible (the header version check rejects a mismatched peer before
+ * its differently-sized session body can be misread).
  */
-#define DEFW_VERSION_NUMBER		 2
+#define DEFW_VERSION_NUMBER		 3
 
 #define MAX_STR_LEN			1024
 #define MAX_SHORT_STR_LEN		128

--- a/src/defw_common.h
+++ b/src/defw_common.h
@@ -46,6 +46,8 @@
 
 /* Framework Environment Variables needed from C */
 #define DEFW_PATH 		"DEFW_PATH" /* base installation path */
+#define DEFW_TRANSPORT_ENV	"DEFW_TRANSPORT" /* "tcp" (default) or "ofi" */
+#define DEFW_OFI_PROVIDER_ENV	"DEFW_OFI_PROVIDER" /* optional fi provider filter */
 
 #ifndef _UUID_UUID_H
 typedef unsigned char uuid_t[16];

--- a/src/defw_common.h
+++ b/src/defw_common.h
@@ -19,7 +19,10 @@
 #define BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */
 #define BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
 
-#define DEFW_VERSION_NUMBER		 1
+/* Bumped to 2: the message header now carries the sender uuid instead of
+ * the sender IP address. Old and new builds are intentionally incompatible.
+ */
+#define DEFW_VERSION_NUMBER		 2
 
 #define MAX_STR_LEN			1024
 #define MAX_SHORT_STR_LEN		128

--- a/src/defw_listener.c
+++ b/src/defw_listener.c
@@ -262,7 +262,6 @@ static defw_rc_t process_agent_message(defw_agent_blk_t *agent, int fd)
 	defw_message_hdr_t hdr = {0};
 	char *buffer;
 	defw_msg_process_fn_t proc_fn;
-	int cmp;
 
 	/* get the header first */
 	rc = readTcpMessage(fd, (char *)&hdr, sizeof(hdr),
@@ -278,12 +277,21 @@ static defw_rc_t process_agent_message(defw_agent_blk_t *agent, int fd)
 		return EN_DEFW_RC_BAD_VERSION;
 	}
 
-	/* if the ips don't match ignore the message */
-	hdr.ip.s_addr = ntohl(hdr.ip.s_addr);
-	if ((cmp = memcmp(&agent->addr.sin_addr, &hdr.ip, sizeof(hdr.ip)))) {
-		PERROR("IP addresses don't match");
-		PERROR("agent IP = %s", inet_ntoa(agent->addr.sin_addr));
-		PERROR("hdr IP = %s", inet_ntoa(hdr.ip));
+	/* Validate the sender identity by remote uuid. A brand new
+	 * connection has no uuid yet; it arrives in the session info, so we
+	 * trust the first message and let process_msg_session_info record
+	 * the uuid (trust on first use). Once the uuid is known, a mismatch
+	 * means the message did not come from the agent that owns this
+	 * connection and is dropped.
+	 */
+	if (!uuid_is_null(agent->id.remote_uuid) &&
+	    uuid_compare(agent->id.remote_uuid, hdr.sender_uuid)) {
+		char got[UUID_STR_LEN], expected[UUID_STR_LEN];
+
+		uuid_unparse_lower(hdr.sender_uuid, got);
+		uuid_unparse_lower(agent->id.remote_uuid, expected);
+		PERROR("sender uuid mismatch: expected %s got %s",
+		       expected, got);
 		return EN_DEFW_RC_BAD_ADDR;
 	}
 

--- a/src/defw_listener.c
+++ b/src/defw_listener.c
@@ -19,6 +19,7 @@
 #include "libdefw_agent.h"
 #include "defw_message.h"
 #include "defw_listener.h"
+#include "defw_transport.h"
 #include "defw_print.h"
 
 #define MAX_AGENT_NOTIFICATION 1024
@@ -135,6 +136,36 @@ int defw_get_highest_fd(void)
 	return iMaxFd;
 }
 
+/* If OFI is active locally and the peer advertised an OFI address we have not
+ * inserted yet, add it to the address vector and cache the resulting fi_addr
+ * on the agent. A peer with ofi_addrlen 0 (TCP-only, or its transport is tcp)
+ * is left untouched, which is how a mixed TCP/OFI cluster keeps working. Safe
+ * to call from any message that carries a defw_msg_session_t (session info or
+ * heartbeat); the DEFW_AGENT_OFI_ADDR_VALID guard makes it idempotent.
+ */
+static void maybe_insert_ofi_addr(defw_agent_blk_t *agent,
+				  defw_msg_session_t *ses)
+{
+	unsigned int ofi_addrlen;
+	uint64_t fi_addr;
+
+	if (agent->state & DEFW_AGENT_OFI_ADDR_VALID)
+		return;
+
+	ofi_addrlen = ntohl(ses->ofi_addrlen);
+	if (ofi_addrlen == 0 || ofi_addrlen > DEFW_OFI_MAX_ADDRLEN)
+		return;
+
+	if (defw_transport_ofi_av_insert(ses->ofi_addr, ofi_addrlen,
+					 &fi_addr) != EN_DEFW_RC_OK)
+		return;
+
+	agent->ofi_addr = fi_addr;
+	set_agent_state(agent, DEFW_AGENT_OFI_ADDR_VALID);
+	PMSG("OFI address inserted for agent %s: fi_addr=%lu",
+	     agent->name, (unsigned long)fi_addr);
+}
+
 static defw_rc_t process_msg_session_info(char *msg, defw_agent_blk_t *agent)
 {
 	defw_msg_session_t *ses = (defw_msg_session_t *)msg;
@@ -156,6 +187,10 @@ static defw_rc_t process_msg_session_info(char *msg, defw_agent_blk_t *agent)
 		       existing->name, existing->iRpcFd);
 		if (ses->rpc_setup)
 			set_agent_state(existing, DEFW_AGENT_RPC_CHANNEL_CONNECTED);
+		/* in case the OFI address was not learned on the first
+		 * (control) connection, try again here while we hold a ref
+		 */
+		maybe_insert_ofi_addr(existing, ses);
 		/* release ref count acquired when you found the agent */
 		defw_release_agent_blk(existing, false);
 		/* agent should never be the same as existing.
@@ -193,6 +228,7 @@ static defw_rc_t process_msg_session_info(char *msg, defw_agent_blk_t *agent)
 	set_agent_state(agent, DEFW_AGENT_STATE_ALIVE);
 	unset_agent_state(agent, DEFW_AGENT_STATE_NEW);
 	gettimeofday(&agent->time_stamp, NULL);
+	maybe_insert_ofi_addr(agent, ses);
 	PDEBUG("First connection on a new agent (%s) is the Cntrl connection: %d",
 		agent->name, agent->iFileDesc);
 
@@ -237,6 +273,10 @@ static defw_rc_t process_msg_hb(char *msg, defw_agent_blk_t *agent)
 	strncpy(agent->name, hb->node_name, MAX_STR_LEN);
 	agent->name[MAX_STR_LEN-1] = '\0';
 	gettimeofday(&agent->time_stamp, NULL);
+	/* a peer we connected to advertises its OFI address in its heartbeats;
+	 * learn it here so we can reach it over the fabric
+	 */
+	maybe_insert_ofi_addr(agent, hb);
 
 	return EN_DEFW_RC_OK;
 }

--- a/src/defw_listener.c
+++ b/src/defw_listener.c
@@ -374,6 +374,75 @@ static defw_rc_t process_agent_message(defw_agent_blk_t *agent, int fd)
 	return rc;
 }
 
+/*
+ * defw_ofi_dispatch
+ *   Dispatch a framed message that arrived as a single [header][body] buffer
+ *   (the OFI receive path) rather than a streamed socket read. Mirrors
+ *   process_agent_message: check the version, find the sending agent by the
+ *   header uuid, and run the registered handler on the body.
+ *
+ *   Only RPC message types travel over OFI (the control channel stays on
+ *   TCP), and their Python handlers copy the payload, so KEEP_DATA is not
+ *   expected here; this always frees the buffer it is given.
+ */
+defw_rc_t defw_ofi_dispatch(char *buf, size_t buflen)
+{
+	defw_message_hdr_t *hdr = (defw_message_hdr_t *)buf;
+	defw_msg_process_fn_t proc_fn;
+	defw_agent_blk_t *agent;
+	defw_agent_uuid_t id;
+	unsigned int type, len, version;
+	defw_rc_t rc;
+
+	if (buflen < sizeof(*hdr)) {
+		PERROR("OFI msg smaller than header: %zu", buflen);
+		free(buf);
+		return EN_DEFW_RC_FAIL;
+	}
+
+	version = ntohl(hdr->version);
+	if (version != DEFW_VERSION_NUMBER) {
+		PERROR("OFI msg version %u != %d", version, DEFW_VERSION_NUMBER);
+		free(buf);
+		return EN_DEFW_RC_BAD_VERSION;
+	}
+
+	type = ntohl(hdr->type);
+	len = ntohl(hdr->len);
+
+	if (type >= EN_MSG_TYPE_MAX) {
+		PERROR("OFI msg unknown type %u", type);
+		free(buf);
+		return EN_DEFW_RC_UNKNOWN_MESSAGE;
+	}
+
+	if (sizeof(*hdr) + len > buflen) {
+		PERROR("OFI msg truncated: body %u buf %zu", len, buflen);
+		free(buf);
+		return EN_DEFW_RC_FAIL;
+	}
+
+	memset(&id, 0, sizeof(id));
+	uuid_copy(id.remote_uuid, hdr->sender_uuid);
+	agent = defw_find_agent_by_uuid_global(&id);
+	if (!agent) {
+		PERROR("OFI msg from an unknown agent");
+		free(buf);
+		return EN_DEFW_RC_AGENT_NOT_FOUND;
+	}
+
+	proc_fn = msg_process_tbl[type];
+	if (proc_fn)
+		rc = proc_fn(buf + sizeof(*hdr), agent);
+	else
+		rc = EN_DEFW_RC_UNKNOWN_MESSAGE;
+
+	defw_release_agent_blk(agent, false);
+	free(buf);
+
+	return rc;
+}
+
 int process_new_agents_helper(defw_agent_blk_t *agent, void *user_data)
 {
 	connection_info_t *info = user_data;

--- a/src/defw_message.h
+++ b/src/defw_message.h
@@ -18,10 +18,15 @@ typedef enum {
 	EN_MSG_TYPE_MAX
 } defw_msg_type_t;
 
+/* The sender identity is the sender's remote uuid rather than its source
+ * IP address. A uuid is meaningful on any transport (TCP sockets, but also
+ * connectionless fabrics where there is no per-peer socket to read an
+ * address from), so this is the identity check shared by all transports.
+ */
 typedef struct defw_message_hdr_s {
 	defw_msg_type_t type;
 	unsigned int len;
-	struct in_addr ip;
+	uuid_t sender_uuid;
 	unsigned int version;
 } defw_message_hdr_t;
 

--- a/src/defw_message.h
+++ b/src/defw_message.h
@@ -3,6 +3,13 @@
 
 #include "defw_common.h"
 
+/* Maximum serialized OFI endpoint address (fi_getname output) carried in the
+ * session handshake. libfabric endpoint names are small (e.g. 16 bytes for the
+ * tcp provider); 256 is a generous upper bound shared by the message layer and
+ * the OFI transport.
+ */
+#define DEFW_OFI_MAX_ADDRLEN 256
+
 typedef struct defw_agent_uuid_s {
 	uuid_t remote_uuid;  /* uuid of the remote process/agent */
 	uuid_t blk_uuid; /* assigned locally. unique to agent */
@@ -33,6 +40,11 @@ typedef struct defw_message_hdr_s {
 /* add a uuid in the session message.
  * Active sends to passive as part of session creation
  * Passive sends to active in the heart beat
+ *
+ * ofi_addr carries the sender's serialized OFI endpoint name so a peer can
+ * reach it over the fabric. ofi_addrlen is 0 when the sender has no OFI
+ * endpoint (TCP-only build, or transport is tcp), which tells the receiver to
+ * leave that peer on the TCP path.
  */
 typedef struct defw_msg_session_s {
 	defw_agent_uuid_t agent_id;
@@ -42,6 +54,8 @@ typedef struct defw_msg_session_s {
 	int listen_port;
 	char node_name[MAX_STR_LEN];
 	char node_hostname[MAX_STR_LEN];
+	unsigned int ofi_addrlen;
+	unsigned char ofi_addr[DEFW_OFI_MAX_ADDRLEN];
 } defw_msg_session_t;
 
 typedef struct defw_msg_num_agents_query_s {

--- a/src/defw_sl.c
+++ b/src/defw_sl.c
@@ -24,6 +24,7 @@
 #include "defw.h"
 #include "defw_sl.h"
 #include "libdefw_agent.h"
+#include "defw_transport.h"
 #include "defw_print.h"
 
 extern defw_config_params_t g_defw_cfg;
@@ -238,6 +239,11 @@ run_pure_python:
 			g_defw_cfg.outlog);
 		return EN_DEFW_RC_LOG_CREATION_FAILURE;
 	}
+
+	/* Select the message transport (TCP or, if configured and available,
+	 * libfabric/OFI) before the listener starts.
+	 */
+	defw_transport_startup();
 
 	if (g_defw_cfg.l_info.listen_address.sin_port != 0) {
 		if (defw_spawn_listener(&l_thread_id)) {

--- a/src/defw_sl.c
+++ b/src/defw_sl.c
@@ -333,5 +333,9 @@ defw_rc_t defw_exec_py(char *py_code)
 void defw_shutdown(void)
 {
 	defw_listener_shutdown();
+	/* stop the OFI progress thread (if any) before finalizing Python, so
+	 * no fabric receive can dispatch into a shutting-down interpreter
+	 */
+	defw_transport_shutdown();
 	python_finalize();
 }

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -92,4 +92,19 @@ void defw_transport_set_ops(defw_transport_ops_t *ops);
 /* The built-in TCP transport. */
 defw_transport_ops_t *defw_transport_tcp_ops(void);
 
+/* Read transport configuration (DEFW_TRANSPORT / DEFW_OFI_PROVIDER) and
+ * select the active transport. Called once at startup before the listener
+ * is spawned. Falls back to TCP if OFI is requested but unavailable, so it
+ * never fails the caller.
+ */
+void defw_transport_startup(void);
+
+/* Bring up the libfabric/OFI transport and, on success, make it the active
+ * transport. provider may be NULL to let libfabric choose. Returns
+ * EN_DEFW_RC_FAIL when DEFw was built without libfabric support. Defined in
+ * defw_transport_ofi.c (real implementation under HAVE_LIBFABRIC, otherwise
+ * a stub).
+ */
+defw_rc_t defw_transport_ofi_init(const char *provider);
+
 #endif /* DEFW_TRANSPORT_H */

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -1,0 +1,95 @@
+#ifndef DEFW_TRANSPORT_H
+#define DEFW_TRANSPORT_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "defw_common.h"
+#include "defw_message.h"
+#include "defw_agent.h"
+
+/*
+ * DEFw transport abstraction.
+ *
+ * DEFw historically spoke TCP directly: the agent and listener code called
+ * the socket send/receive helpers by name. This ops table is the seam that
+ * lets an alternate transport (e.g. libfabric/OFI) carry the same framed
+ * messages without the agent, listener, or Python layers knowing which
+ * transport is in use.
+ *
+ * Phase 0 introduces the seam and routes the outbound framed-message path
+ * through it, with a single built-in TCP implementation that preserves the
+ * historical behavior exactly. Later phases add an OFI implementation and
+ * wire the remaining ops (endpoint init, peer connect, event-loop progress).
+ */
+
+/*
+ * Logical channel a message travels on. TCP maps these onto the agent's two
+ * sockets (control and RPC); a tagged transport such as OFI maps them onto
+ * bits in the message tag (see defw_tag_make below).
+ */
+typedef enum {
+	EN_DEFW_CHANNEL_CTRL = 0, /* session info + heartbeats */
+	EN_DEFW_CHANNEL_RPC,      /* python request / response / event */
+} defw_channel_t;
+
+/*
+ * Tag layout for tagged transports: [channel:8][msg_type:8][reserved:48].
+ * TCP does not use tags (it demultiplexes by socket and reads the framed
+ * header), but the encoding lives here so every transport shares one
+ * definition. These helpers are unused until the OFI transport lands.
+ */
+static inline uint64_t defw_tag_make(defw_channel_t ch, defw_msg_type_t type)
+{
+	return (((uint64_t)ch & 0xff) << 56) |
+	       (((uint64_t)type & 0xff) << 48);
+}
+
+static inline defw_channel_t defw_tag_channel(uint64_t tag)
+{
+	return (defw_channel_t)((tag >> 56) & 0xff);
+}
+
+static inline defw_msg_type_t defw_tag_msg_type(uint64_t tag)
+{
+	return (defw_msg_type_t)((tag >> 48) & 0xff);
+}
+
+/*
+ * Transport operations.
+ *
+ * Phase 0 exercises send(). The remaining ops are declared now to document
+ * the interface a transport must provide; they are left NULL by the TCP
+ * transport because the existing listener/connect code still owns those
+ * paths for TCP. The OFI transport will implement all of them, and the
+ * listener/connect code will be routed through init/connect/progress in a
+ * later phase.
+ */
+typedef struct defw_transport_ops_s {
+	const char *name;
+
+	/* Send a framed DEFw message to agent on the given channel. */
+	defw_rc_t (*send)(defw_agent_blk_t *agent, defw_channel_t ch,
+			  char *buf, size_t len, defw_msg_type_t type);
+
+	/* Reserved for later phases; NULL in phase 0. */
+	defw_rc_t (*init)(void *listener_info);
+	defw_rc_t (*connect)(defw_agent_blk_t *agent);
+	defw_rc_t (*progress)(void);
+	void      (*disconnect)(defw_agent_blk_t *agent);
+	void      (*fini)(void);
+} defw_transport_ops_t;
+
+/* Return the active transport ops. Defaults to the built-in TCP transport
+ * and is never NULL.
+ */
+defw_transport_ops_t *defw_transport_ops(void);
+
+/* Select the active transport. A NULL argument is ignored. Used by later
+ * phases to switch to OFI based on configuration.
+ */
+void defw_transport_set_ops(defw_transport_ops_t *ops);
+
+/* The built-in TCP transport. */
+defw_transport_ops_t *defw_transport_tcp_ops(void);
+
+#endif /* DEFW_TRANSPORT_H */

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -107,4 +107,18 @@ void defw_transport_startup(void);
  */
 defw_rc_t defw_transport_ofi_init(const char *provider);
 
+/* Copy this process's OFI endpoint address into buf (for the session
+ * handshake). On entry *len is the buffer size; on success it is set to the
+ * address length. Returns EN_DEFW_RC_FAIL when OFI is not active (so the
+ * caller advertises no OFI address and the peer stays on TCP).
+ */
+defw_rc_t defw_transport_ofi_local_addr(void *buf, size_t *len);
+
+/* Insert a peer's OFI address (as received in the session handshake) into the
+ * local address vector and return the resulting fi_addr_t as a uint64_t.
+ * Returns EN_DEFW_RC_FAIL when OFI is not active or the insert fails.
+ */
+defw_rc_t defw_transport_ofi_av_insert(const void *addr, size_t addrlen,
+				       uint64_t *fi_addr_out);
+
 #endif /* DEFW_TRANSPORT_H */

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -121,4 +121,18 @@ defw_rc_t defw_transport_ofi_local_addr(void *buf, size_t *len);
 defw_rc_t defw_transport_ofi_av_insert(const void *addr, size_t addrlen,
 				       uint64_t *fi_addr_out);
 
+/* Dispatch a framed DEFw message received as a single [header][body] buffer
+ * (the OFI receive path), as opposed to a streamed socket read. Validates the
+ * header, finds the sending agent by uuid, and runs the registered handler.
+ * Takes ownership of buf and frees it. Defined in defw_listener.c where the
+ * message dispatch table lives.
+ */
+defw_rc_t defw_ofi_dispatch(char *buf, size_t buflen);
+
+/* Tear down the active transport (stops the OFI progress thread and closes
+ * fabric resources). Safe to call for the TCP transport (no-op). Called from
+ * defw_shutdown().
+ */
+void defw_transport_shutdown(void);
+
 #endif /* DEFW_TRANSPORT_H */

--- a/src/defw_transport_ofi.c
+++ b/src/defw_transport_ofi.c
@@ -1,0 +1,229 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include "defw_transport.h"
+#include "defw_agent.h"
+#include "defw_common.h"
+#include "defw_global.h"
+#include "defw_print.h"
+
+/*
+ * libfabric / OFI transport.
+ *
+ * Phase 1a brings up a single reliable-datagram (FI_EP_RDM) endpoint with an
+ * address vector and a completion queue, and makes OFI the active transport.
+ * The data path is NOT wired yet: ofi_send() delegates to TCP so the
+ * framework stays fully functional while the fabric path is built out. Later
+ * phases add the session-info address exchange (fi_av_insert), the tagged
+ * send/receive data path (fi_tsend/fi_trecv), and the CQ progress thread.
+ *
+ * The whole libfabric implementation is compiled only when DEFw is built with
+ * libfabric (HAVE_LIBFABRIC, set by the SConstruct when libfabric is found).
+ * Otherwise a stub reports that OFI is unavailable and the caller falls back
+ * to TCP.
+ */
+
+#ifdef HAVE_LIBFABRIC
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_errno.h>
+
+/* Minimum libfabric API version DEFw targets. The container ships 2.3.1. */
+#define DEFW_OFI_VERSION	FI_VERSION(1, 20)
+#define DEFW_OFI_MAX_ADDRLEN	256
+
+/*
+ * OFI transport state. One RDM endpoint per process. Peers are inserted into
+ * the address vector and referenced by fi_addr_t (stored in the agent block
+ * in a later phase); local_addr holds this process's endpoint name for the
+ * session-info exchange that a later phase adds.
+ */
+typedef struct defw_ofi_state_s {
+	struct fi_info    *info;
+	struct fid_fabric *fabric;
+	struct fid_domain *domain;
+	struct fid_ep     *ep;
+	struct fid_av     *av;
+	struct fid_cq     *cq;
+	uint8_t            local_addr[DEFW_OFI_MAX_ADDRLEN];
+	size_t             local_addrlen;
+	bool               up;
+} defw_ofi_state_t;
+
+static defw_ofi_state_t g_ofi;
+
+/*
+ * Phase 1a: the OFI data path is not wired yet. Keep sending over TCP so the
+ * framework stays functional while the endpoint is validated. A later phase
+ * replaces this body with fi_tsend() and a per-peer TCP fallback.
+ */
+static defw_rc_t ofi_send(defw_agent_blk_t *agent, defw_channel_t ch,
+			  char *buf, size_t len, defw_msg_type_t type)
+{
+	return defw_transport_tcp_ops()->send(agent, ch, buf, len, type);
+}
+
+static void ofi_fini(void)
+{
+	if (g_ofi.ep)
+		fi_close(&g_ofi.ep->fid);
+	if (g_ofi.cq)
+		fi_close(&g_ofi.cq->fid);
+	if (g_ofi.av)
+		fi_close(&g_ofi.av->fid);
+	if (g_ofi.domain)
+		fi_close(&g_ofi.domain->fid);
+	if (g_ofi.fabric)
+		fi_close(&g_ofi.fabric->fid);
+	if (g_ofi.info)
+		fi_freeinfo(g_ofi.info);
+	memset(&g_ofi, 0, sizeof(g_ofi));
+}
+
+static defw_transport_ops_t ofi_ops = {
+	.name = "ofi",
+	.send = ofi_send,
+	.init = NULL,
+	.connect = NULL,
+	.progress = NULL,
+	.disconnect = NULL,
+	.fini = ofi_fini,
+};
+
+defw_rc_t defw_transport_ofi_init(const char *provider)
+{
+	struct fi_info *hints;
+	struct fi_cq_attr cq_attr;
+	struct fi_av_attr av_attr;
+	int ret;
+
+	memset(&g_ofi, 0, sizeof(g_ofi));
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	memset(&av_attr, 0, sizeof(av_attr));
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EN_DEFW_RC_OOM;
+
+	/* Reliable datagram, message + tagged capabilities. FI_CONTEXT is
+	 * accepted here because most providers require per-operation context;
+	 * the tagged data path in a later phase supplies it.
+	 */
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG | FI_TAGGED;
+	hints->mode = FI_CONTEXT;
+	hints->domain_attr->threading = FI_THREAD_SAFE;
+	if (provider && strlen(provider)) {
+		hints->fabric_attr->prov_name = strdup(provider);
+		if (!hints->fabric_attr->prov_name) {
+			fi_freeinfo(hints);
+			return EN_DEFW_RC_OOM;
+		}
+	}
+
+	ret = fi_getinfo(DEFW_OFI_VERSION, NULL, NULL, 0, hints, &g_ofi.info);
+	fi_freeinfo(hints);
+	if (ret) {
+		PERROR("fi_getinfo failed: %s", fi_strerror(-ret));
+		return EN_DEFW_RC_FAIL;
+	}
+
+	PMSG("OFI provider selected: %s", g_ofi.info->fabric_attr->prov_name);
+
+	ret = fi_fabric(g_ofi.info->fabric_attr, &g_ofi.fabric, NULL);
+	if (ret) {
+		PERROR("fi_fabric failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	ret = fi_domain(g_ofi.fabric, g_ofi.info, &g_ofi.domain, NULL);
+	if (ret) {
+		PERROR("fi_domain failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	av_attr.type = FI_AV_MAP;
+	ret = fi_av_open(g_ofi.domain, &av_attr, &g_ofi.av, NULL);
+	if (ret) {
+		PERROR("fi_av_open failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.wait_obj = FI_WAIT_UNSPEC;
+	cq_attr.size = g_ofi.info->rx_attr->size;
+	ret = fi_cq_open(g_ofi.domain, &cq_attr, &g_ofi.cq, NULL);
+	if (ret) {
+		PERROR("fi_cq_open failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	ret = fi_endpoint(g_ofi.domain, g_ofi.info, &g_ofi.ep, NULL);
+	if (ret) {
+		PERROR("fi_endpoint failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	ret = fi_ep_bind(g_ofi.ep, &g_ofi.av->fid, 0);
+	if (ret) {
+		PERROR("fi_ep_bind(av) failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	ret = fi_ep_bind(g_ofi.ep, &g_ofi.cq->fid, FI_TRANSMIT | FI_RECV);
+	if (ret) {
+		PERROR("fi_ep_bind(cq) failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	ret = fi_enable(g_ofi.ep);
+	if (ret) {
+		PERROR("fi_enable failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	/* Cache our endpoint name for the session-info exchange a later phase
+	 * adds. Peers insert this into their address vector to reach us.
+	 */
+	g_ofi.local_addrlen = sizeof(g_ofi.local_addr);
+	ret = fi_getname(&g_ofi.ep->fid, g_ofi.local_addr, &g_ofi.local_addrlen);
+	if (ret) {
+		PERROR("fi_getname failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	g_ofi.up = true;
+	PMSG("OFI endpoint up: provider=%s addrlen=%zu",
+	     g_ofi.info->fabric_attr->prov_name, g_ofi.local_addrlen);
+
+	/* Make OFI the active transport. The data path still delegates to TCP
+	 * in this phase (see ofi_send).
+	 */
+	defw_transport_set_ops(&ofi_ops);
+
+	return EN_DEFW_RC_OK;
+
+err:
+	ofi_fini();
+	return EN_DEFW_RC_FAIL;
+}
+
+#else /* !HAVE_LIBFABRIC */
+
+defw_rc_t defw_transport_ofi_init(const char *provider)
+{
+	(void)provider;
+	PERROR("libfabric support was not built into DEFw");
+	return EN_DEFW_RC_FAIL;
+}
+
+#endif /* HAVE_LIBFABRIC */

--- a/src/defw_transport_ofi.c
+++ b/src/defw_transport_ofi.c
@@ -15,12 +15,16 @@
 /*
  * libfabric / OFI transport.
  *
- * Phase 1a brings up a single reliable-datagram (FI_EP_RDM) endpoint with an
- * address vector and a completion queue, and makes OFI the active transport.
- * The data path is NOT wired yet: ofi_send() delegates to TCP so the
- * framework stays fully functional while the fabric path is built out. Later
- * phases add the session-info address exchange (fi_av_insert), the tagged
- * send/receive data path (fi_tsend/fi_trecv), and the CQ progress thread.
+ * A single reliable-datagram (FI_EP_RDM) endpoint per process. Peers are
+ * reached by fi_addr_t entries in the address vector, learned over the TCP
+ * session handshake (phase 1b). The control channel (session info and
+ * heartbeats) stays on TCP because it bootstraps the OFI addresses and
+ * provides liveness; RPC traffic moves onto the fabric.
+ *
+ * Sends assemble the framed [header][body] message and block on a dedicated
+ * transmit CQ until completion (serialized, so the temporary buffer is safe
+ * to free). Receives are handled by a progress thread draining a separate
+ * receive CQ into the shared message dispatch (defw_ofi_dispatch).
  *
  * The whole libfabric implementation is compiled only when DEFw is built with
  * libfabric (HAVE_LIBFABRIC, set by the SConstruct when libfabric is found).
@@ -32,52 +36,208 @@
 
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
+#include <rdma/fi_eq.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_cm.h>
-#include <rdma/fi_tagged.h>
 #include <rdma/fi_errno.h>
 
 /* Minimum libfabric API version DEFw targets. The container ships 2.3.1. */
 #define DEFW_OFI_VERSION	FI_VERSION(1, 20)
 /* DEFW_OFI_MAX_ADDRLEN is shared with the message layer (defw_message.h). */
 
-/*
- * OFI transport state. One RDM endpoint per process. Peers are inserted into
- * the address vector and referenced by fi_addr_t (stored in the agent block
- * in a later phase); local_addr holds this process's endpoint name for the
- * session-info exchange that a later phase adds.
+/* Receive buffer pool. Each posted buffer holds one eager message (header
+ * included). A message larger than this is a phase-3 (large payload / RMA)
+ * concern and shows up here as a truncation error.
  */
+#define DEFW_OFI_RECV_BUF_SIZE		(256 * 1024)
+#define DEFW_OFI_NUM_RECV_BUFS		8
+/* how long a blocking send waits for its completion before giving up (ms) */
+#define DEFW_OFI_SEND_TIMEOUT_MS	20000
+/* progress-thread CQ poll timeout (ms); short enough to notice shutdown */
+#define DEFW_OFI_PROGRESS_TIMEOUT_MS	1000
+
+/* A posted receive buffer. fi_context MUST be first so a completion's
+ * op_context (which points at it) casts straight back to the buffer.
+ */
+struct ofi_recv_buf {
+	struct fi_context context;
+	unsigned char     data[DEFW_OFI_RECV_BUF_SIZE];
+};
+
 typedef struct defw_ofi_state_s {
-	struct fi_info    *info;
-	struct fid_fabric *fabric;
-	struct fid_domain *domain;
-	struct fid_ep     *ep;
-	struct fid_av     *av;
-	struct fid_cq     *cq;
-	uint8_t            local_addr[DEFW_OFI_MAX_ADDRLEN];
-	size_t             local_addrlen;
-	bool               up;
+	struct fi_info      *info;
+	struct fid_fabric   *fabric;
+	struct fid_domain   *domain;
+	struct fid_ep       *ep;
+	struct fid_av       *av;
+	struct fid_cq       *tx_cq;  /* send completions (drained by the sender) */
+	struct fid_cq       *rx_cq;  /* recv completions (drained by progress) */
+	uint8_t              local_addr[DEFW_OFI_MAX_ADDRLEN];
+	size_t               local_addrlen;
+	struct ofi_recv_buf *recv_bufs;
+	pthread_t            progress_thread;
+	volatile bool        progress_run;
+	pthread_mutex_t      send_lock;  /* one outstanding send at a time */
+	struct fi_context    send_ctx;
+	bool                 up;
 } defw_ofi_state_t;
 
 static defw_ofi_state_t g_ofi;
 
+static ssize_t ofi_post_recv(struct ofi_recv_buf *buf)
+{
+	return fi_recv(g_ofi.ep, buf->data, DEFW_OFI_RECV_BUF_SIZE, NULL,
+		       FI_ADDR_UNSPEC, &buf->context);
+}
+
 /*
- * Phase 1a: the OFI data path is not wired yet. Keep sending over TCP so the
- * framework stays functional while the endpoint is validated. A later phase
- * replaces this body with fi_tsend() and a per-peer TCP fallback.
+ * Assemble the framed message ([header][body]) and send it to dst over the
+ * fabric, blocking until the send completes so the temporary buffer is safe
+ * to free. Sends are serialized, so exactly one completion is outstanding on
+ * the transmit CQ and it is unambiguously ours.
+ */
+static defw_rc_t ofi_send_msg(fi_addr_t dst, char *body, size_t bodylen,
+			      defw_msg_type_t type)
+{
+	size_t msglen = sizeof(defw_message_hdr_t) + bodylen;
+	struct fi_cq_msg_entry entry;
+	defw_message_hdr_t *hdr;
+	defw_rc_t rc = EN_DEFW_RC_OK;
+	char *msg;
+	ssize_t ret;
+
+	msg = malloc(msglen);
+	if (!msg)
+		return EN_DEFW_RC_OOM;
+
+	hdr = (defw_message_hdr_t *)msg;
+	hdr->type = htonl(type);
+	hdr->len = htonl((unsigned int)bodylen);
+	uuid_copy(hdr->sender_uuid, g_defw_cfg.uuid);
+	hdr->version = htonl(DEFW_VERSION_NUMBER);
+	if (bodylen)
+		memcpy(msg + sizeof(*hdr), body, bodylen);
+
+	PDEBUG("OFI RPC send: type=%d bodylen=%zu to fi_addr=%lu",
+	       type, bodylen, (unsigned long)dst);
+
+	pthread_mutex_lock(&g_ofi.send_lock);
+
+	do {
+		ret = fi_send(g_ofi.ep, msg, msglen, NULL, dst, &g_ofi.send_ctx);
+		if (ret == -FI_EAGAIN)
+			fi_cq_read(g_ofi.tx_cq, &entry, 1); /* drive progress */
+	} while (ret == -FI_EAGAIN);
+
+	if (ret) {
+		PERROR("fi_send failed: %s", fi_strerror((int)-ret));
+		rc = EN_DEFW_RC_SOCKET_FAIL;
+		goto out;
+	}
+
+	ret = fi_cq_sread(g_ofi.tx_cq, &entry, 1, NULL, DEFW_OFI_SEND_TIMEOUT_MS);
+	if (ret == 1) {
+		/* send completed */
+	} else if (ret == -FI_EAVAIL) {
+		struct fi_cq_err_entry err = {0};
+
+		fi_cq_readerr(g_ofi.tx_cq, &err, 0);
+		PERROR("OFI send completion error: %s",
+		       fi_cq_strerror(g_ofi.tx_cq, err.prov_errno,
+				      err.err_data, NULL, 0));
+		rc = EN_DEFW_RC_SOCKET_FAIL;
+	} else if (ret == -FI_EAGAIN) {
+		PERROR("OFI send completion timed out");
+		rc = EN_DEFW_RC_TIMEOUT;
+	} else {
+		PERROR("fi_cq_sread(tx) failed: %s", fi_strerror((int)-ret));
+		rc = EN_DEFW_RC_SOCKET_FAIL;
+	}
+
+out:
+	pthread_mutex_unlock(&g_ofi.send_lock);
+	free(msg);
+	return rc;
+}
+
+/*
+ * Active-transport send. The control channel (session info + heartbeats)
+ * always stays on TCP: it bootstraps the OFI addresses and is the liveness
+ * signal. RPC traffic goes over the fabric once we have learned the peer's
+ * OFI address (DEFW_AGENT_OFI_ADDR_VALID); until then, or for a TCP-only
+ * peer, it falls back to TCP.
  */
 static defw_rc_t ofi_send(defw_agent_blk_t *agent, defw_channel_t ch,
 			  char *buf, size_t len, defw_msg_type_t type)
 {
-	return defw_transport_tcp_ops()->send(agent, ch, buf, len, type);
+	/* control channel always on TCP; RPC on the fabric only once the
+	 * endpoint is up and we know the peer's OFI address, otherwise TCP
+	 */
+	if (ch == EN_DEFW_CHANNEL_CTRL || !g_ofi.up ||
+	    !(agent->state & DEFW_AGENT_OFI_ADDR_VALID))
+		return defw_transport_tcp_ops()->send(agent, ch, buf, len, type);
+
+	return ofi_send_msg((fi_addr_t)agent->ofi_addr, buf, len, type);
+}
+
+static void *ofi_progress_thread(void *arg)
+{
+	struct fi_cq_msg_entry entry;
+	ssize_t ret;
+
+	(void)arg;
+
+	while (g_ofi.progress_run) {
+		ret = fi_cq_sread(g_ofi.rx_cq, &entry, 1, NULL,
+				  DEFW_OFI_PROGRESS_TIMEOUT_MS);
+		if (ret == 1) {
+			struct ofi_recv_buf *buf = entry.op_context;
+			size_t msglen = entry.len;
+			char *copy = malloc(msglen);
+
+			/* copy out and re-post the pinned buffer immediately so
+			 * the dispatch (which may call into Python) does not
+			 * hold up receive capacity
+			 */
+			if (copy)
+				memcpy(copy, buf->data, msglen);
+			ofi_post_recv(buf);
+			PDEBUG("OFI RPC recv: %zu bytes", msglen);
+			if (copy)
+				defw_ofi_dispatch(copy, msglen);
+		} else if (ret == -FI_EAGAIN) {
+			continue; /* poll timeout; re-check progress_run */
+		} else if (ret == -FI_EAVAIL) {
+			struct fi_cq_err_entry err = {0};
+
+			fi_cq_readerr(g_ofi.rx_cq, &err, 0);
+			PERROR("OFI recv completion error: %s",
+			       fi_cq_strerror(g_ofi.rx_cq, err.prov_errno,
+					      err.err_data, NULL, 0));
+			if (err.op_context)
+				ofi_post_recv(err.op_context);
+		} else {
+			PERROR("fi_cq_sread(rx) failed: %s",
+			       fi_strerror((int)-ret));
+			break;
+		}
+	}
+
+	return NULL;
 }
 
 static void ofi_fini(void)
 {
+	if (g_ofi.progress_run) {
+		g_ofi.progress_run = false;
+		pthread_join(g_ofi.progress_thread, NULL);
+	}
 	if (g_ofi.ep)
 		fi_close(&g_ofi.ep->fid);
-	if (g_ofi.cq)
-		fi_close(&g_ofi.cq->fid);
+	if (g_ofi.tx_cq)
+		fi_close(&g_ofi.tx_cq->fid);
+	if (g_ofi.rx_cq)
+		fi_close(&g_ofi.rx_cq->fid);
 	if (g_ofi.av)
 		fi_close(&g_ofi.av->fid);
 	if (g_ofi.domain)
@@ -86,6 +246,8 @@ static void ofi_fini(void)
 		fi_close(&g_ofi.fabric->fid);
 	if (g_ofi.info)
 		fi_freeinfo(g_ofi.info);
+	free(g_ofi.recv_bufs);
+	pthread_mutex_destroy(&g_ofi.send_lock);
 	memset(&g_ofi, 0, sizeof(g_ofi));
 }
 
@@ -104,28 +266,30 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 	struct fi_info *hints;
 	struct fi_cq_attr cq_attr;
 	struct fi_av_attr av_attr;
-	int ret;
+	int ret, i;
 
 	memset(&g_ofi, 0, sizeof(g_ofi));
-	memset(&cq_attr, 0, sizeof(cq_attr));
 	memset(&av_attr, 0, sizeof(av_attr));
+	pthread_mutex_init(&g_ofi.send_lock, NULL);
 
 	hints = fi_allocinfo();
-	if (!hints)
+	if (!hints) {
+		pthread_mutex_destroy(&g_ofi.send_lock);
 		return EN_DEFW_RC_OOM;
+	}
 
-	/* Reliable datagram, message + tagged capabilities. FI_CONTEXT is
-	 * accepted here because most providers require per-operation context;
-	 * the tagged data path in a later phase supplies it.
+	/* Reliable datagram, message semantics. FI_CONTEXT is accepted because
+	 * most providers require a per-operation context object.
 	 */
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG | FI_TAGGED;
+	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->threading = FI_THREAD_SAFE;
 	if (provider && strlen(provider)) {
 		hints->fabric_attr->prov_name = strdup(provider);
 		if (!hints->fabric_attr->prov_name) {
 			fi_freeinfo(hints);
+			pthread_mutex_destroy(&g_ofi.send_lock);
 			return EN_DEFW_RC_OOM;
 		}
 	}
@@ -134,6 +298,7 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 	fi_freeinfo(hints);
 	if (ret) {
 		PERROR("fi_getinfo failed: %s", fi_strerror(-ret));
+		pthread_mutex_destroy(&g_ofi.send_lock);
 		return EN_DEFW_RC_FAIL;
 	}
 
@@ -158,12 +323,23 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		goto err;
 	}
 
-	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	/* separate transmit and receive completion queues so a blocking send
+	 * can wait on its own completion without racing the progress thread
+	 */
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	cq_attr.format = FI_CQ_FORMAT_MSG;
 	cq_attr.wait_obj = FI_WAIT_UNSPEC;
-	cq_attr.size = g_ofi.info->rx_attr->size;
-	ret = fi_cq_open(g_ofi.domain, &cq_attr, &g_ofi.cq, NULL);
+	cq_attr.size = g_ofi.info->tx_attr->size;
+	ret = fi_cq_open(g_ofi.domain, &cq_attr, &g_ofi.tx_cq, NULL);
 	if (ret) {
-		PERROR("fi_cq_open failed: %s", fi_strerror(-ret));
+		PERROR("fi_cq_open(tx) failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	cq_attr.size = g_ofi.info->rx_attr->size;
+	ret = fi_cq_open(g_ofi.domain, &cq_attr, &g_ofi.rx_cq, NULL);
+	if (ret) {
+		PERROR("fi_cq_open(rx) failed: %s", fi_strerror(-ret));
 		goto err;
 	}
 
@@ -179,9 +355,15 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		goto err;
 	}
 
-	ret = fi_ep_bind(g_ofi.ep, &g_ofi.cq->fid, FI_TRANSMIT | FI_RECV);
+	ret = fi_ep_bind(g_ofi.ep, &g_ofi.tx_cq->fid, FI_TRANSMIT);
 	if (ret) {
-		PERROR("fi_ep_bind(cq) failed: %s", fi_strerror(-ret));
+		PERROR("fi_ep_bind(tx_cq) failed: %s", fi_strerror(-ret));
+		goto err;
+	}
+
+	ret = fi_ep_bind(g_ofi.ep, &g_ofi.rx_cq->fid, FI_RECV);
+	if (ret) {
+		PERROR("fi_ep_bind(rx_cq) failed: %s", fi_strerror(-ret));
 		goto err;
 	}
 
@@ -191,8 +373,8 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		goto err;
 	}
 
-	/* Cache our endpoint name for the session-info exchange a later phase
-	 * adds. Peers insert this into their address vector to reach us.
+	/* Cache our endpoint name for the session-info exchange. Peers insert
+	 * this into their address vector to reach us.
 	 */
 	g_ofi.local_addrlen = sizeof(g_ofi.local_addr);
 	ret = fi_getname(&g_ofi.ep->fid, g_ofi.local_addr, &g_ofi.local_addrlen);
@@ -201,13 +383,36 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		goto err;
 	}
 
+	/* pre-post the receive buffer pool before any peer can send to us */
+	g_ofi.recv_bufs = calloc(DEFW_OFI_NUM_RECV_BUFS,
+				 sizeof(*g_ofi.recv_bufs));
+	if (!g_ofi.recv_bufs) {
+		PERROR("OFI recv buffer allocation failed");
+		goto err;
+	}
+	for (i = 0; i < DEFW_OFI_NUM_RECV_BUFS; i++) {
+		if (ofi_post_recv(&g_ofi.recv_bufs[i])) {
+			PERROR("fi_recv pre-post failed");
+			goto err;
+		}
+	}
+
 	g_ofi.up = true;
+
+	/* start draining receive completions */
+	g_ofi.progress_run = true;
+	if (pthread_create(&g_ofi.progress_thread, NULL,
+			   ofi_progress_thread, NULL)) {
+		PERROR("failed to start OFI progress thread");
+		g_ofi.progress_run = false;
+		g_ofi.up = false;
+		goto err;
+	}
+
 	PMSG("OFI endpoint up: provider=%s addrlen=%zu",
 	     g_ofi.info->fabric_attr->prov_name, g_ofi.local_addrlen);
 
-	/* Make OFI the active transport. The data path still delegates to TCP
-	 * in this phase (see ofi_send).
-	 */
+	/* make OFI the active transport; RPC traffic now uses the fabric */
 	defw_transport_set_ops(&ofi_ops);
 
 	return EN_DEFW_RC_OK;

--- a/src/defw_transport_ofi.c
+++ b/src/defw_transport_ofi.c
@@ -39,7 +39,7 @@
 
 /* Minimum libfabric API version DEFw targets. The container ships 2.3.1. */
 #define DEFW_OFI_VERSION	FI_VERSION(1, 20)
-#define DEFW_OFI_MAX_ADDRLEN	256
+/* DEFW_OFI_MAX_ADDRLEN is shared with the message layer (defw_message.h). */
 
 /*
  * OFI transport state. One RDM endpoint per process. Peers are inserted into
@@ -217,12 +217,65 @@ err:
 	return EN_DEFW_RC_FAIL;
 }
 
+defw_rc_t defw_transport_ofi_local_addr(void *buf, size_t *len)
+{
+	if (!g_ofi.up || !buf || !len)
+		return EN_DEFW_RC_FAIL;
+
+	if (*len < g_ofi.local_addrlen)
+		return EN_DEFW_RC_FAIL;
+
+	memcpy(buf, g_ofi.local_addr, g_ofi.local_addrlen);
+	*len = g_ofi.local_addrlen;
+
+	return EN_DEFW_RC_OK;
+}
+
+defw_rc_t defw_transport_ofi_av_insert(const void *addr, size_t addrlen,
+				       uint64_t *fi_addr_out)
+{
+	fi_addr_t fi_addr = FI_ADDR_UNSPEC;
+	int ret;
+
+	if (!g_ofi.up || !addr || !addrlen || !fi_addr_out)
+		return EN_DEFW_RC_FAIL;
+
+	/* fi_av_insert returns the number of addresses inserted (1), or a
+	 * negative errno on failure.
+	 */
+	ret = fi_av_insert(g_ofi.av, addr, 1, &fi_addr, 0, NULL);
+	if (ret != 1) {
+		PERROR("fi_av_insert returned %d", ret);
+		return EN_DEFW_RC_FAIL;
+	}
+
+	*fi_addr_out = (uint64_t)fi_addr;
+
+	return EN_DEFW_RC_OK;
+}
+
 #else /* !HAVE_LIBFABRIC */
 
 defw_rc_t defw_transport_ofi_init(const char *provider)
 {
 	(void)provider;
 	PERROR("libfabric support was not built into DEFw");
+	return EN_DEFW_RC_FAIL;
+}
+
+defw_rc_t defw_transport_ofi_local_addr(void *buf, size_t *len)
+{
+	(void)buf;
+	(void)len;
+	return EN_DEFW_RC_FAIL;
+}
+
+defw_rc_t defw_transport_ofi_av_insert(const void *addr, size_t addrlen,
+				       uint64_t *fi_addr_out)
+{
+	(void)addr;
+	(void)addrlen;
+	(void)fi_addr_out;
 	return EN_DEFW_RC_FAIL;
 }
 

--- a/src/defw_transport_tcp.c
+++ b/src/defw_transport_tcp.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <netinet/in.h>
@@ -9,6 +10,7 @@
 #include "defw_agent.h"
 #include "libdefw_connect.h"
 #include "defw_common.h"
+#include "defw_global.h"
 #include "defw_print.h"
 
 /*
@@ -61,4 +63,30 @@ void defw_transport_set_ops(defw_transport_ops_t *ops)
 {
 	if (ops)
 		g_transport = ops;
+}
+
+void defw_transport_startup(void)
+{
+	const char *transport = getenv(DEFW_TRANSPORT_ENV);
+
+	/* Default and explicit "tcp": g_transport already points at tcp_ops. */
+	if (!transport || !strcmp(transport, "tcp")) {
+		PDEBUG("DEFw transport: tcp");
+		return;
+	}
+
+	if (!strcmp(transport, "ofi")) {
+		const char *provider = getenv(DEFW_OFI_PROVIDER_ENV);
+		defw_rc_t rc = defw_transport_ofi_init(provider);
+
+		if (rc == EN_DEFW_RC_OK)
+			PMSG("DEFw transport: ofi (provider=%s)",
+			     (provider && strlen(provider)) ? provider : "auto");
+		else
+			PERROR("DEFw transport: ofi requested but unavailable (%s); using tcp",
+			       defw_rc2str(rc));
+		return;
+	}
+
+	PERROR("DEFw transport: unknown transport '%s'; using tcp", transport);
 }

--- a/src/defw_transport_tcp.c
+++ b/src/defw_transport_tcp.c
@@ -1,0 +1,64 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include "defw_transport.h"
+#include "defw_agent.h"
+#include "libdefw_connect.h"
+#include "defw_common.h"
+#include "defw_print.h"
+
+/*
+ * Built-in TCP transport.
+ *
+ * Maps the logical CTRL and RPC channels onto the agent's two sockets and
+ * forwards to the existing framed-message writer (defw_send_msg). This keeps
+ * DEFw's historical wire behavior identical; the ops table simply names the
+ * seam that a fabric transport will later plug into.
+ */
+static defw_rc_t tcp_send(defw_agent_blk_t *agent, defw_channel_t ch,
+			  char *buf, size_t len, defw_msg_type_t type)
+{
+	int fd;
+
+	if (!agent)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	fd = (ch == EN_DEFW_CHANNEL_RPC) ? agent->iRpcFd : agent->iFileDesc;
+
+	return defw_send_msg(fd, buf, len, type);
+}
+
+static defw_transport_ops_t tcp_ops = {
+	.name = "tcp",
+	.send = tcp_send,
+	.init = NULL,
+	.connect = NULL,
+	.progress = NULL,
+	.disconnect = NULL,
+	.fini = NULL,
+};
+
+/* Statically initialized so the accessor is valid before any explicit
+ * transport setup runs.
+ */
+static defw_transport_ops_t *g_transport = &tcp_ops;
+
+defw_transport_ops_t *defw_transport_tcp_ops(void)
+{
+	return &tcp_ops;
+}
+
+defw_transport_ops_t *defw_transport_ops(void)
+{
+	return g_transport;
+}
+
+void defw_transport_set_ops(defw_transport_ops_t *ops)
+{
+	if (ops)
+		g_transport = ops;
+}

--- a/src/defw_transport_tcp.c
+++ b/src/defw_transport_tcp.c
@@ -90,3 +90,11 @@ void defw_transport_startup(void)
 
 	PERROR("DEFw transport: unknown transport '%s'; using tcp", transport);
 }
+
+void defw_transport_shutdown(void)
+{
+	defw_transport_ops_t *ops = g_transport;
+
+	if (ops && ops->fini)
+		ops->fini();
+}

--- a/src/libdefw_agent.c
+++ b/src/libdefw_agent.c
@@ -18,6 +18,7 @@
 #include "defw_list.h"
 #include "defw_python.h"
 #include "defw_listener.h"
+#include "defw_transport.h"
 #include "defw_print.h"
 
 extern fd_set g_tAllSet;
@@ -669,8 +670,9 @@ defw_rc_t defw_send_session_info(defw_agent_blk_t *agent, bool rpc_setup)
 	msg.node_name[MAX_STR_LEN-1] = '\0';
 	gethostname(msg.node_hostname, MAX_STR_LEN);
 
-	rc = defw_send_msg((rpc_setup) ? agent->iRpcFd : agent->iFileDesc,
-			  (char *)&msg, sizeof(msg), EN_MSG_TYPE_SESSION_INFO);
+	rc = defw_transport_ops()->send(agent,
+			(rpc_setup) ? EN_DEFW_CHANNEL_RPC : EN_DEFW_CHANNEL_CTRL,
+			(char *)&msg, sizeof(msg), EN_MSG_TYPE_SESSION_INFO);
 	if (rc != EN_DEFW_RC_OK) {
 		PERROR("Failed to send heart beat %s\n",
 			defw_rc2str(rc));
@@ -696,8 +698,8 @@ defw_rc_t defw_send_hb(defw_agent_blk_t *agent)
 	//       agent->iRpcFd);
 
 	/* send the heart beat */
-	rc = defw_send_msg(agent->iFileDesc, (char *)&msg,
-			   sizeof(msg), EN_MSG_TYPE_HB);
+	rc = defw_transport_ops()->send(agent, EN_DEFW_CHANNEL_CTRL,
+			(char *)&msg, sizeof(msg), EN_MSG_TYPE_HB);
 	if (rc != EN_DEFW_RC_OK) {
 		PERROR("Failed to send heart beat %s\n",
 			defw_rc2str(rc));
@@ -969,7 +971,8 @@ defw_send(char *dst_uuid, char *blk_uuid, char *yaml, defw_msg_type_t type)
 
 	set_agent_state(agent_blk, DEFW_AGENT_WORK_IN_PROGRESS);
 
-	rc = defw_send_msg(agent_blk->iRpcFd, yaml, msg_size, type);
+	rc = defw_transport_ops()->send(agent_blk, EN_DEFW_CHANNEL_RPC,
+			yaml, msg_size, type);
 	if (rc != EN_DEFW_RC_OK) {
 		PERROR("Failed to send rpc message: %s", yaml);
 		goto fail_rpc;

--- a/src/libdefw_agent.c
+++ b/src/libdefw_agent.c
@@ -655,10 +655,13 @@ defw_agent_blk_t *find_agent_by_name_global(char *hostname, char *name)
 defw_rc_t defw_send_session_info(defw_agent_blk_t *agent, bool rpc_setup)
 {
 	defw_msg_session_t msg;
+	size_t ofi_len = sizeof(msg.ofi_addr);
 	int rc;
 
 //	PDEBUG("Sending session info to agent %p on fd %d\n",
 //		agent, (rpc_setup) ? agent->iRpcFd : agent->iFileDesc);
+
+	memset(&msg, 0, sizeof(msg));
 
 	uuid_copy(msg.agent_id.remote_uuid, g_defw_cfg.uuid);
 
@@ -669,6 +672,12 @@ defw_rc_t defw_send_session_info(defw_agent_blk_t *agent, bool rpc_setup)
 	strncpy(msg.node_name, g_defw_cfg.l_info.hb_info.node_name, MAX_STR_LEN);
 	msg.node_name[MAX_STR_LEN-1] = '\0';
 	gethostname(msg.node_hostname, MAX_STR_LEN);
+
+	/* advertise our OFI endpoint address when OFI is active; otherwise
+	 * ofi_addrlen stays 0 (from the memset) and the peer keeps us on TCP
+	 */
+	if (defw_transport_ofi_local_addr(msg.ofi_addr, &ofi_len) == EN_DEFW_RC_OK)
+		msg.ofi_addrlen = htonl((unsigned int)ofi_len);
 
 	rc = defw_transport_ops()->send(agent,
 			(rpc_setup) ? EN_DEFW_CHANNEL_RPC : EN_DEFW_CHANNEL_CTRL,
@@ -684,7 +693,10 @@ defw_rc_t defw_send_session_info(defw_agent_blk_t *agent, bool rpc_setup)
 defw_rc_t defw_send_hb(defw_agent_blk_t *agent)
 {
 	defw_msg_session_t msg;
+	size_t ofi_len = sizeof(msg.ofi_addr);
 	int rc;
+
+	memset(&msg, 0, sizeof(msg));
 
 	uuid_copy(msg.agent_id.remote_uuid, g_defw_cfg.uuid);
 
@@ -693,6 +705,12 @@ defw_rc_t defw_send_hb(defw_agent_blk_t *agent)
 	strncpy(msg.node_name, g_defw_cfg.l_info.hb_info.node_name, MAX_STR_LEN);
 	msg.node_name[MAX_STR_LEN-1] = '\0';
 	gethostname(msg.node_hostname, MAX_STR_LEN);
+
+	/* carry our OFI address in the heartbeat too, so a peer that connected
+	 * to us (and only receives our heartbeats) can also learn it
+	 */
+	if (defw_transport_ofi_local_addr(msg.ofi_addr, &ofi_len) == EN_DEFW_RC_OK)
+		msg.ofi_addrlen = htonl((unsigned int)ofi_len);
 
 	//PDEBUG("agent %s: fd %d rpc %d\n", agent->name, agent->iFileDesc,
 	//       agent->iRpcFd);

--- a/src/libdefw_connect.c
+++ b/src/libdefw_connect.c
@@ -14,8 +14,10 @@
 #include <strings.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
+#include <uuid/uuid.h>
 #include "defw_print.h"
 #include "libdefw_connect.h"
+#include "defw.h"
 
 static defw_rc_t doNonBlockingConnect(int iSockFd, struct sockaddr *psSA,
 				      int iSAlen, int iNsec)
@@ -204,9 +206,6 @@ defw_rc_t populateMsgHdr(int rsocket, char *msg_hdr,
 			 int defw_version_number)
 {
 	defw_message_hdr_t *hdr = NULL;
-	struct sockaddr_in sock;
-	int len = sizeof(sock);
-	int rc;
 
 	if (rsocket == INVALID_TCP_SOCKET ||
 	    msg_hdr == NULL) {
@@ -217,19 +216,13 @@ defw_rc_t populateMsgHdr(int rsocket, char *msg_hdr,
 
 	hdr = (defw_message_hdr_t *)msg_hdr;
 
-	/* get the local IP address we are connected on */
-	rc = getsockname(rsocket,
-			(struct sockaddr *)&sock,
-			(socklen_t *)&len);
-	if (rc) {
-		PERROR("getsockname failure %s:%s:%d",
-		       strerror(errno), strerror(rc), rc);
-		return EN_DEFW_RC_FAIL;
-	}
-
 	hdr->type = htonl(msg_type);
 	hdr->len = htonl(msg_size);
-	hdr->ip.s_addr = htonl(sock.sin_addr.s_addr);
+	/* Stamp the sender identity: our own remote uuid. This replaces the
+	 * previous source-IP stamp and is valid regardless of transport.
+	 * uuid_t is a byte array, so no endian conversion is needed.
+	 */
+	uuid_copy(hdr->sender_uuid, g_defw_cfg.uuid);
 	hdr->version = htonl(defw_version_number);
 
 	return EN_DEFW_RC_OK;


### PR DESCRIPTION
## Summary

Adds a **libfabric (OFI) transport** to DEFw so the client/server RPC path can
run over HPC fabrics (Slingshot and friends) instead of only TCP. Design:
[openQSE/QFw#27](https://github.com/openQSE/QFw/pull/27).

**This supersedes #14** (phase 0). Phase 0 and phase 1 were validated together
in the QFw-SLURM-Cluster container, so they are presented here as one stack.
The five commits are individually scoped and reviewable in order.

TCP remains the default and the per-peer fallback; libfabric is opt-in via
`DEFW_TRANSPORT=ofi`. A build without libfabric compiles TCP-only (no new hard
dependency).

## Commits

1. **identify message senders by uuid instead of ip** — the message header
   carried the sender's source IPv4 address; replace it with the sender's
   remote uuid, which is meaningful on any transport (wire change,
   `DEFW_VERSION_NUMBER` 1→2).
2. **route framed sends through a transport ops table** — introduce
   `defw_transport.h` (a small ops seam) and `defw_transport_tcp.c`; route the
   three framed-send sites through `defw_transport_ops()->send()`. No behavior
   change.
3. **phase 1a — OFI endpoint bring-up** — SConstruct detects libfabric
   (pkg-config → `LIBFABRIC_DIR`); `defw_transport_ofi.c` opens an `FI_EP_RDM`
   endpoint (fabric/domain/AV/CQ). `DEFW_TRANSPORT`/`DEFW_OFI_PROVIDER` select
   the transport at startup.
4. **phase 1b — OFI address exchange** — carry the endpoint address in the
   session/heartbeat handshake and `fi_av_insert` peers into the address
   vector, caching each `fi_addr_t` on the agent (wire change, version 2→3).
5. **phase 1c — RPC data path over the fabric** — the control channel stays on
   TCP (bootstrap + liveness); RPC moves onto `fi_send`/`fi_recv` with split
   tx/rx CQs, a receive progress thread, and a per-peer TCP fallback.

## Validation (QFw-SLURM-Cluster container, Rocky 10)

Rebuilt DEFw (`qfw_build.sh --defw`) and ran `examples/qfw_mpi_smoke.sh` under
`DEFW_TRANSPORT=ofi` with two providers:

- **tcp** — `OFI endpoint up: provider=tcp`; 16 RPC sends / 16 recvs over the
  fabric (PY_REQUEST + PY_RESPONSE) to both peers; `status: ok`.
- **sm2** (gen-2 shared memory) — `OFI endpoint up: provider=sm2`; 16/16 RPCs
  over shared memory; `status: ok`. (Note: the legacy `shm` provider advertises
  nothing on libfabric 2.3.1; `sm2` is its replacement.)
- **fallback** — when a provider is unavailable, all agents cleanly degrade to
  TCP and the workflow still passes.

No `fi_*` errors, truncation, timeouts, or version mismatches in any run.

## Companion PR

The QFw launcher must propagate `DEFW_TRANSPORT`/`DEFW_OFI_PROVIDER` to the
resmgr/service agents (they are launched with a curated environment). That is a
one-line allowlist change in a separate QFw PR; the two should merge together.

## Notes for reviewers

- **Wire-format**: the header (phase 0) and session body (phase 1b) changed, so
  `DEFW_VERSION_NUMBER` is now 3; old and new builds intentionally reject each
  other via the header version check.
- **Debug markers**: 1c adds per-RPC `PDEBUG` lines ("OFI RPC send/recv"),
  silent unless log level is debug/all — useful for phase-2 provider bring-up;
  happy to trim if preferred.
- **Follow-ups (not in this PR)**: an OFI-capable peer still lazily opens an
  (unused) TCP RPC socket — harmless, to be optimized; messages larger than the
  256 KB eager buffer are a phase-3 (large payload / RMA) concern.
