### PR TITLE
DEFw: libfabric transport phase 3 - RMA for large payloads

### DIFF
--- a/python/infra/defw_attachments.py
+++ b/python/infra/defw_attachments.py
@@ -1,0 +1,118 @@
+"""
+Transparent binary-attachment handling for DEFw RPCs.
+
+Large buffer-protocol objects (NumPy arrays, and bytes/bytearray above a size
+threshold) that appear inside RPC arguments or return values are pulled out of
+the YAML-serialized message and carried as separate binary attachments, then
+transparently restored on the receiving side. This keeps large payloads out of
+the text YAML encoding so they can travel over an efficient binary path
+(eager/inline today; an RMA fi_read rendezvous for RMA-capable transports in a
+later slice). Application code is unchanged: it passes and returns NumPy arrays
+(or bytes) normally.
+
+The message body still serializes to YAML, but where a large buffer was found
+it now holds a small marker dict recording the attachment index and enough
+metadata (kind, and for arrays the shape and dtype) to reconstruct the object.
+"""
+import logging
+
+# Reserved key identifying an extracted-attachment marker in the YAML message.
+# Chosen to be extremely unlikely to collide with an application dict key.
+ATTACH_MARKER_KEY = '__defw_attachment__'
+
+# bytes/bytearray at or above this many bytes are extracted as attachments;
+# smaller ones stay inline in YAML (which handles them fine). NumPy arrays are
+# always extracted because YAML cannot represent them.
+DEFAULT_ATTACH_THRESHOLD = 4096
+
+try:
+	import numpy as _np
+except Exception:
+	_np = None
+
+
+def _is_ndarray(obj):
+	return _np is not None and isinstance(obj, _np.ndarray)
+
+
+def _marker(index, kind, **meta):
+	m = {ATTACH_MARKER_KEY: index, 'kind': kind}
+	m.update(meta)
+	return m
+
+
+def _extract(obj, attachments, threshold):
+	# NumPy array: always an attachment (YAML cannot serialize it). Make it
+	# contiguous first, and keep the resulting object alive by storing it in
+	# the attachments list (the send path reads its buffer).
+	if _is_ndarray(obj):
+		arr = _np.ascontiguousarray(obj)
+		index = len(attachments)
+		attachments.append(arr)
+		return _marker(index, 'ndarray',
+			       shape=list(arr.shape), dtype=str(arr.dtype))
+
+	# bytes/bytearray: attachment only above the threshold.
+	if isinstance(obj, (bytes, bytearray)):
+		if len(obj) >= threshold:
+			index = len(attachments)
+			attachments.append(bytes(obj))
+			return _marker(index, 'bytes')
+		return obj
+
+	if isinstance(obj, dict):
+		return {k: _extract(v, attachments, threshold)
+			for k, v in obj.items()}
+	if isinstance(obj, list):
+		return [_extract(v, attachments, threshold) for v in obj]
+	if isinstance(obj, tuple):
+		return tuple(_extract(v, attachments, threshold) for v in obj)
+
+	return obj
+
+
+def extract_attachments(msg, threshold=DEFAULT_ATTACH_THRESHOLD):
+	"""Walk msg and pull large buffer-protocol objects out into attachments.
+
+	Returns (transformed_msg, attachments) where transformed_msg is a copy of
+	msg with each extracted buffer replaced by a marker dict, and attachments
+	is a list of buffer-protocol objects (bytes or contiguous NumPy arrays) in
+	marker-index order. msg itself is not mutated. attachments is empty when
+	nothing qualified, in which case transformed_msg is equivalent to msg.
+	"""
+	attachments = []
+	transformed = _extract(msg, attachments, threshold)
+	return transformed, attachments
+
+
+def _reinject(obj, attachments):
+	if isinstance(obj, dict):
+		if ATTACH_MARKER_KEY in obj:
+			index = obj[ATTACH_MARKER_KEY]
+			buf = attachments[index]
+			kind = obj.get('kind')
+			if kind == 'ndarray':
+				if _np is None:
+					raise RuntimeError(
+						"received a NumPy array attachment but "
+						"numpy is not available to restore it")
+				arr = _np.frombuffer(buf, dtype=obj['dtype'])
+				return arr.reshape(obj['shape'])
+			# kind == 'bytes' (or unknown): hand back raw bytes
+			return bytes(buf)
+		return {k: _reinject(v, attachments) for k, v in obj.items()}
+	if isinstance(obj, list):
+		return [_reinject(v, attachments) for v in obj]
+	if isinstance(obj, tuple):
+		return tuple(_reinject(v, attachments) for v in obj)
+	return obj
+
+
+def reinject_attachments(msg, attachments):
+	"""Inverse of extract_attachments: replace markers in msg with the
+	corresponding attachment buffers (reconstructing NumPy arrays from their
+	recorded shape/dtype). Returns msg unchanged when there are no
+	attachments."""
+	if not attachments:
+		return msg
+	return _reinject(msg, attachments)

--- a/python/infra/defw_attachments.py
+++ b/python/infra/defw_attachments.py
@@ -16,15 +16,26 @@ metadata (kind, and for arrays the shape and dtype) to reconstruct the object.
 """
 import base64
 import logging
+import os
 
 # Reserved key identifying an extracted-attachment marker in the YAML message.
 # Chosen to be extremely unlikely to collide with an application dict key.
 ATTACH_MARKER_KEY = '__defw_attachment__'
 
-# Reserved top-level key carrying the inline (base64) attachment payloads in
-# the eager transfer used by phase 3b. Phase 3c replaces this with an RMA
-# fi_read rendezvous for large payloads on RMA-capable transports.
+# Reserved top-level key carrying the inline (base64) attachment payloads.
+# This is the eager path: it works on every transport and stays the right
+# choice for small payloads and for peers we cannot reach over the fabric.
 ATTACH_DATA_KEY = '__defw_attachment_data__'
+
+# Reserved top-level key carrying RMA descriptors instead of payloads. The
+# message then names the data rather than containing it, and the receiver
+# reads it directly out of the sender's memory over the fabric.
+ATTACH_RMA_KEY = '__defw_attachment_rma__'
+
+# Set DEFW_RMA_ATTACHMENTS=1 to move payloads by RMA where the peer supports
+# it. Off by default: the rendezvous is in place but choosing it
+# automatically (on payload size) is a separate step.
+RMA_ENV = 'DEFW_RMA_ATTACHMENTS'
 
 # bytes/bytearray at or above this many bytes are extracted as attachments;
 # smaller ones stay inline in YAML (which handles them fine). NumPy arrays are
@@ -135,32 +146,128 @@ def _to_bytes(buf):
 	return memoryview(buf).cast('B').tobytes()
 
 
-def attach_encode(msg, threshold=DEFAULT_ATTACH_THRESHOLD):
-	"""Serialize msg to a YAML string, carrying any large buffers inline as
-	base64 attachments.
+_agent_mod = None
+_agent_mod_tried = False
+
+
+def _rma_ops():
+	"""The C entry points backing the RMA path, or None when they are not
+	available -- a DEFw built without them, or this module imported on its
+	own for testing. Callers fall back to the inline path."""
+	global _agent_mod, _agent_mod_tried
+	if not _agent_mod_tried:
+		_agent_mod_tried = True
+		try:
+			import cdefw_agent
+			_agent_mod = cdefw_agent
+		except Exception:
+			_agent_mod = None
+	return _agent_mod
+
+
+def rma_requested():
+	return os.environ.get(RMA_ENV, '') not in ('', '0', 'no', 'false')
+
+
+def _rma_usable(blk_uuid):
+	"""Whether this message's payloads can travel by RMA to blk_uuid."""
+	if not blk_uuid or not rma_requested():
+		return False
+	ops = _rma_ops()
+	if not ops:
+		return False
+	try:
+		return bool(ops.defw_rma_available(str(blk_uuid)))
+	except Exception as e:
+		logging.debug(f"RMA availability check failed: {e}")
+		return False
+
+
+def _rma_publish_all(attachments):
+	"""Register every attachment for the peer to read and return the
+	descriptors. Returns None if any registration fails, having released the
+	ones already made, so the caller can fall back to sending inline."""
+	ops = _rma_ops()
+	descs = []
+	for a in attachments:
+		try:
+			rc, desc = ops.defw_rma_publish(_to_bytes(a))
+		except Exception as e:
+			logging.warning(f"RMA publish raised, using inline: {e}")
+			rc, desc = -1, None
+		if rc or not desc:
+			for d in descs:
+				ops.defw_rma_discard(d['handle'])
+			return None
+		handle, key, addr, length = (int(v) for v in desc.split(':'))
+		descs.append({'handle': handle, 'key': key,
+			      'addr': addr, 'len': length})
+	return descs
+
+
+def attach_encode(msg, blk_uuid=None, threshold=DEFAULT_ATTACH_THRESHOLD):
+	"""Serialize msg to a YAML string, carrying any large buffers as
+	attachments rather than in the YAML itself.
+
+	Attachments travel one of two ways. If RMA is enabled and the peer named
+	by blk_uuid is reachable over the fabric, the message carries only
+	descriptors and the receiver reads the data out of our memory directly;
+	each region stays registered until the receiver acknowledges it.
+	Otherwise the payloads are inlined as base64, which works everywhere.
 
 	When msg contains no large buffers this is exactly yaml.dump(msg), so
-	ordinary RPCs are unaffected. Inline base64 is the eager transfer for
-	phase 3b; phase 3c moves large payloads over an RMA fi_read rendezvous on
-	RMA-capable transports instead.
+	ordinary RPCs are unaffected either way.
 	"""
 	import yaml
 	transformed, attachments = extract_attachments(msg, threshold)
 	if attachments:
-		transformed[ATTACH_DATA_KEY] = [
-			base64.b64encode(_to_bytes(a)).decode('ascii')
-			for a in attachments]
+		descs = None
+		if _rma_usable(blk_uuid):
+			descs = _rma_publish_all(attachments)
+		if descs is not None:
+			transformed[ATTACH_RMA_KEY] = descs
+		else:
+			transformed[ATTACH_DATA_KEY] = [
+				base64.b64encode(_to_bytes(a)).decode('ascii')
+				for a in attachments]
 	return yaml.dump(transformed)
 
 
-def attach_load(msg_str):
-	"""Inverse of attach_encode: yaml.load msg_str and restore any inline
-	attachments it carries. Equivalent to a plain yaml.load for messages
-	without attachments."""
+def _rma_fetch_all(descs, blk_uuid):
+	ops = _rma_ops()
+	if not ops:
+		raise RuntimeError("received RMA attachments but this DEFw build "
+				   "has no RMA support to fetch them")
+	if not blk_uuid:
+		raise RuntimeError("received RMA attachments but the sending "
+				   "agent is unknown, so they cannot be fetched")
+	attachments = []
+	for d in descs:
+		rc, data = ops.defw_rma_fetch(str(blk_uuid), d['handle'],
+					      d['key'], d['addr'], d['len'])
+		if rc or data is None:
+			raise RuntimeError(
+				f"RMA fetch failed (rc={rc}) for {d['len']} bytes "
+				f"from agent {blk_uuid}")
+		attachments.append(data)
+	return attachments
+
+
+def attach_load(msg_str, blk_uuid=None):
+	"""Inverse of attach_encode: yaml.load msg_str and restore any
+	attachments it carries, reading them over the fabric when the message
+	carries descriptors rather than inline data. blk_uuid identifies the
+	sending agent and is required only for the RMA case. Equivalent to a
+	plain yaml.load for messages without attachments."""
 	import yaml
 	obj = yaml.load(msg_str, Loader=yaml.Loader)
-	if isinstance(obj, dict) and ATTACH_DATA_KEY in obj:
-		encoded = obj.pop(ATTACH_DATA_KEY)
-		attachments = [base64.b64decode(s) for s in encoded]
-		obj = reinject_attachments(obj, attachments)
+	if isinstance(obj, dict):
+		if ATTACH_RMA_KEY in obj:
+			descs = obj.pop(ATTACH_RMA_KEY)
+			obj = reinject_attachments(
+				obj, _rma_fetch_all(descs, blk_uuid))
+		elif ATTACH_DATA_KEY in obj:
+			encoded = obj.pop(ATTACH_DATA_KEY)
+			attachments = [base64.b64decode(s) for s in encoded]
+			obj = reinject_attachments(obj, attachments)
 	return obj

--- a/python/infra/defw_attachments.py
+++ b/python/infra/defw_attachments.py
@@ -22,20 +22,30 @@ import os
 # Chosen to be extremely unlikely to collide with an application dict key.
 ATTACH_MARKER_KEY = '__defw_attachment__'
 
-# Reserved top-level key carrying the inline (base64) attachment payloads.
-# This is the eager path: it works on every transport and stays the right
-# choice for small payloads and for peers we cannot reach over the fabric.
+# Reserved top-level key carrying the attachment payloads, in marker-index
+# order. Each entry either holds the data (a base64 string) or says where to
+# read it (an RMA descriptor dict), so the two can be mixed freely within one
+# message and each payload travels whichever way suits it.
 ATTACH_DATA_KEY = '__defw_attachment_data__'
 
-# Reserved top-level key carrying RMA descriptors instead of payloads. The
-# message then names the data rather than containing it, and the receiver
-# reads it directly out of the sender's memory over the fabric.
-ATTACH_RMA_KEY = '__defw_attachment_rma__'
-
-# Set DEFW_RMA_ATTACHMENTS=1 to move payloads by RMA where the peer supports
-# it. Off by default: the rendezvous is in place but choosing it
-# automatically (on payload size) is a separate step.
+# Set DEFW_RMA_ATTACHMENTS=0 to keep every payload inline regardless of size.
+# RMA is used by default where it is available.
 RMA_ENV = 'DEFW_RMA_ATTACHMENTS'
+
+# Payloads at or above this many bytes travel by RMA when the peer can serve
+# it; smaller ones stay inline, where an extra round trip would cost more than
+# the base64 encoding it saves. Overridable with DEFW_RMA_THRESHOLD, and
+# setting it to 0 sends every attachment by RMA, which is how the RMA path is
+# exercised with small payloads.
+#
+# The default is a judgement rather than a measurement: base64 inflates a
+# payload by a third, and the fabric's eager receive buffer is 256 KiB, so
+# inline payloads much above 192 KiB push the whole message off the eager path
+# anyway. 64 KiB sits well below that and well above the small arrays that
+# ride along with ordinary RPCs. Worth revisiting with numbers when the
+# statevector path adopts this.
+DEFAULT_RMA_THRESHOLD = 64 * 1024
+RMA_THRESHOLD_ENV = 'DEFW_RMA_THRESHOLD'
 
 # bytes/bytearray at or above this many bytes are extracted as attachments;
 # smaller ones stay inline in YAML (which handles them fine). NumPy arrays are
@@ -165,13 +175,20 @@ def _rma_ops():
 	return _agent_mod
 
 
-def rma_requested():
-	return os.environ.get(RMA_ENV, '') not in ('', '0', 'no', 'false')
+def rma_enabled():
+	return os.environ.get(RMA_ENV, '') not in ('0', 'no', 'false', 'off')
+
+
+def rma_threshold():
+	try:
+		return int(os.environ[RMA_THRESHOLD_ENV])
+	except (KeyError, ValueError):
+		return DEFAULT_RMA_THRESHOLD
 
 
 def _rma_usable(blk_uuid):
-	"""Whether this message's payloads can travel by RMA to blk_uuid."""
-	if not blk_uuid or not rma_requested():
+	"""Whether payloads in this message can travel by RMA to blk_uuid."""
+	if not blk_uuid or not rma_enabled():
 		return False
 	ops = _rma_ops()
 	if not ops:
@@ -183,37 +200,61 @@ def _rma_usable(blk_uuid):
 		return False
 
 
-def _rma_publish_all(attachments):
-	"""Register every attachment for the peer to read and return the
-	descriptors. Returns None if any registration fails, having released the
-	ones already made, so the caller can fall back to sending inline."""
-	ops = _rma_ops()
-	descs = []
+def _rma_publish(ops, data):
+	"""Register one payload for the peer to read, or return None to let the
+	caller fall back to sending it inline."""
+	try:
+		rc, desc = ops.defw_rma_publish(data)
+	except Exception as e:
+		logging.warning(f"RMA publish raised, sending inline instead: {e}")
+		return None
+	if rc or not desc:
+		logging.warning(f"RMA publish failed (rc={rc}), "
+				f"sending {len(data)} bytes inline instead")
+		return None
+	handle, key, addr, length = (int(v) for v in desc.split(':'))
+	return {'handle': handle, 'key': key, 'addr': addr, 'len': length}
+
+
+def _encode_payloads(attachments, blk_uuid, published):
+	"""Turn attachments into the wire payload list, choosing per payload
+	between an RMA descriptor and inline base64."""
+	use_rma = _rma_usable(blk_uuid)
+	threshold = rma_threshold()
+	ops = _rma_ops() if use_rma else None
+	payloads = []
+
 	for a in attachments:
-		try:
-			rc, desc = ops.defw_rma_publish(_to_bytes(a))
-		except Exception as e:
-			logging.warning(f"RMA publish raised, using inline: {e}")
-			rc, desc = -1, None
-		if rc or not desc:
-			for d in descs:
-				ops.defw_rma_discard(d['handle'])
-			return None
-		handle, key, addr, length = (int(v) for v in desc.split(':'))
-		descs.append({'handle': handle, 'key': key,
-			      'addr': addr, 'len': length})
-	return descs
+		data = _to_bytes(a)
+		desc = None
+		if use_rma and len(data) >= threshold:
+			desc = _rma_publish(ops, data)
+		if desc is not None:
+			published.append(desc['handle'])
+			payloads.append(desc)
+		else:
+			payloads.append(base64.b64encode(data).decode('ascii'))
+
+	return payloads
 
 
-def attach_encode(msg, blk_uuid=None, threshold=DEFAULT_ATTACH_THRESHOLD):
+def attach_encode(msg, blk_uuid=None, threshold=DEFAULT_ATTACH_THRESHOLD,
+		  published=None):
 	"""Serialize msg to a YAML string, carrying any large buffers as
 	attachments rather than in the YAML itself.
 
-	Attachments travel one of two ways. If RMA is enabled and the peer named
-	by blk_uuid is reachable over the fabric, the message carries only
-	descriptors and the receiver reads the data out of our memory directly;
-	each region stays registered until the receiver acknowledges it.
-	Otherwise the payloads are inlined as base64, which works everywhere.
+	Each attachment travels whichever way suits it. One at or above the RMA
+	threshold, going to a peer reachable over the fabric, is left in our
+	memory and named in the message by a descriptor; the receiver reads it
+	directly and the region stays registered until it acknowledges. Anything
+	smaller, or bound for a peer that cannot do RMA, is inlined as base64.
+	The two mix freely within a message, and a payload that cannot be
+	registered simply goes inline instead.
+
+	published, if given, is extended with the registration handle of every
+	payload left in our memory. A caller that fails to send the message
+	should pass it to attach_discard, or those registrations stay live until
+	the endpoint is torn down.
 
 	When msg contains no large buffers this is exactly yaml.dump(msg), so
 	ordinary RPCs are unaffected either way.
@@ -221,53 +262,60 @@ def attach_encode(msg, blk_uuid=None, threshold=DEFAULT_ATTACH_THRESHOLD):
 	import yaml
 	transformed, attachments = extract_attachments(msg, threshold)
 	if attachments:
-		descs = None
-		if _rma_usable(blk_uuid):
-			descs = _rma_publish_all(attachments)
-		if descs is not None:
-			transformed[ATTACH_RMA_KEY] = descs
-		else:
-			transformed[ATTACH_DATA_KEY] = [
-				base64.b64encode(_to_bytes(a)).decode('ascii')
-				for a in attachments]
+		transformed[ATTACH_DATA_KEY] = _encode_payloads(
+			attachments, blk_uuid,
+			published if published is not None else [])
 	return yaml.dump(transformed)
 
 
-def _rma_fetch_all(descs, blk_uuid):
+def attach_discard(published):
+	"""Release registrations made for a message that was never sent."""
 	ops = _rma_ops()
 	if not ops:
-		raise RuntimeError("received RMA attachments but this DEFw build "
-				   "has no RMA support to fetch them")
+		return
+	for handle in published:
+		try:
+			ops.defw_rma_discard(handle)
+		except Exception as e:
+			logging.warning(f"RMA discard of handle {handle} failed: {e}")
+
+
+def _rma_fetch(desc, blk_uuid):
+	ops = _rma_ops()
+	if not ops:
+		raise RuntimeError("message carries an RMA attachment but this "
+				   "DEFw build has no RMA support to fetch it")
 	if not blk_uuid:
-		raise RuntimeError("received RMA attachments but the sending "
-				   "agent is unknown, so they cannot be fetched")
-	attachments = []
-	for d in descs:
-		rc, data = ops.defw_rma_fetch(str(blk_uuid), d['handle'],
-					      d['key'], d['addr'], d['len'])
-		if rc or data is None:
-			raise RuntimeError(
-				f"RMA fetch failed (rc={rc}) for {d['len']} bytes "
-				f"from agent {blk_uuid}")
-		attachments.append(data)
-	return attachments
+		raise RuntimeError("message carries an RMA attachment but the "
+				   "sending agent is unknown, so it cannot be "
+				   "fetched")
+	rc, data = ops.defw_rma_fetch(str(blk_uuid), desc['handle'],
+				      desc['key'], desc['addr'], desc['len'])
+	if rc or data is None:
+		raise RuntimeError(
+			f"RMA fetch failed (rc={rc}) for {desc['len']} bytes "
+			f"from agent {blk_uuid}")
+	return data
+
+
+def _decode_payloads(payloads, blk_uuid):
+	"""Inverse of _encode_payloads: an entry either holds the data or names
+	a region to read it from."""
+	return [_rma_fetch(p, blk_uuid) if isinstance(p, dict)
+		else base64.b64decode(p)
+		for p in payloads]
 
 
 def attach_load(msg_str, blk_uuid=None):
 	"""Inverse of attach_encode: yaml.load msg_str and restore any
-	attachments it carries, reading them over the fabric when the message
-	carries descriptors rather than inline data. blk_uuid identifies the
-	sending agent and is required only for the RMA case. Equivalent to a
-	plain yaml.load for messages without attachments."""
+	attachments it carries, reading over the fabric those the message names
+	rather than contains. blk_uuid identifies the sending agent and is
+	needed only for the latter. Equivalent to a plain yaml.load for messages
+	without attachments."""
 	import yaml
 	obj = yaml.load(msg_str, Loader=yaml.Loader)
-	if isinstance(obj, dict):
-		if ATTACH_RMA_KEY in obj:
-			descs = obj.pop(ATTACH_RMA_KEY)
-			obj = reinject_attachments(
-				obj, _rma_fetch_all(descs, blk_uuid))
-		elif ATTACH_DATA_KEY in obj:
-			encoded = obj.pop(ATTACH_DATA_KEY)
-			attachments = [base64.b64decode(s) for s in encoded]
-			obj = reinject_attachments(obj, attachments)
+	if isinstance(obj, dict) and ATTACH_DATA_KEY in obj:
+		payloads = obj.pop(ATTACH_DATA_KEY)
+		obj = reinject_attachments(obj,
+					   _decode_payloads(payloads, blk_uuid))
 	return obj

--- a/python/infra/defw_attachments.py
+++ b/python/infra/defw_attachments.py
@@ -14,11 +14,17 @@ The message body still serializes to YAML, but where a large buffer was found
 it now holds a small marker dict recording the attachment index and enough
 metadata (kind, and for arrays the shape and dtype) to reconstruct the object.
 """
+import base64
 import logging
 
 # Reserved key identifying an extracted-attachment marker in the YAML message.
 # Chosen to be extremely unlikely to collide with an application dict key.
 ATTACH_MARKER_KEY = '__defw_attachment__'
+
+# Reserved top-level key carrying the inline (base64) attachment payloads in
+# the eager transfer used by phase 3b. Phase 3c replaces this with an RMA
+# fi_read rendezvous for large payloads on RMA-capable transports.
+ATTACH_DATA_KEY = '__defw_attachment_data__'
 
 # bytes/bytearray at or above this many bytes are extracted as attachments;
 # smaller ones stay inline in YAML (which handles them fine). NumPy arrays are
@@ -116,3 +122,45 @@ def reinject_attachments(msg, attachments):
 	if not attachments:
 		return msg
 	return _reinject(msg, attachments)
+
+
+def _to_bytes(buf):
+	if isinstance(buf, (bytes, bytearray)):
+		return bytes(buf)
+	# NumPy: tobytes() is unambiguous and works for every dtype (memoryview
+	# cast to 'B' can reject non-standard formats such as complex).
+	if _is_ndarray(buf):
+		return buf.tobytes()
+	# any other buffer-protocol object
+	return memoryview(buf).cast('B').tobytes()
+
+
+def attach_encode(msg, threshold=DEFAULT_ATTACH_THRESHOLD):
+	"""Serialize msg to a YAML string, carrying any large buffers inline as
+	base64 attachments.
+
+	When msg contains no large buffers this is exactly yaml.dump(msg), so
+	ordinary RPCs are unaffected. Inline base64 is the eager transfer for
+	phase 3b; phase 3c moves large payloads over an RMA fi_read rendezvous on
+	RMA-capable transports instead.
+	"""
+	import yaml
+	transformed, attachments = extract_attachments(msg, threshold)
+	if attachments:
+		transformed[ATTACH_DATA_KEY] = [
+			base64.b64encode(_to_bytes(a)).decode('ascii')
+			for a in attachments]
+	return yaml.dump(transformed)
+
+
+def attach_load(msg_str):
+	"""Inverse of attach_encode: yaml.load msg_str and restore any inline
+	attachments it carries. Equivalent to a plain yaml.load for messages
+	without attachments."""
+	import yaml
+	obj = yaml.load(msg_str, Loader=yaml.Loader)
+	if isinstance(obj, dict) and ATTACH_DATA_KEY in obj:
+		encoded = obj.pop(ATTACH_DATA_KEY)
+		attachments = [base64.b64decode(s) for s in encoded]
+		obj = reinject_attachments(obj, attachments)
+	return obj

--- a/python/infra/defw_workers.py
+++ b/python/infra/defw_workers.py
@@ -8,6 +8,7 @@ from defw import client_agents, service_agents, \
 				active_client_agents, active_service_agents, \
 				me, preferences, service_apis
 from defw_util import print_thread_stack_trace_to_logger
+from defw_attachments import attach_encode, attach_load
 import defw
 
 from collections import deque
@@ -54,7 +55,7 @@ class WorkerEvent:
 		else:
 			self.msg_yaml = None
 			if msg:
-				self.msg_yaml = yaml.load(msg, Loader=yaml.Loader)
+				self.msg_yaml = attach_load(msg)
 		stack_trace_str = "".join(traceback.format_stack())
 		logging.defw_stacktrace(
 			f"workerEvent generated from:\n{stack_trace_str}"
@@ -504,7 +505,7 @@ def put_connect_complete(status, uuid_str):
 def send_rsp(wr):
 	rc = defw_send_rsp(wr.remote_uuid,
 					  wr.blk_uuid,
-					  yaml.dump(wr.msg))
+					  attach_encode(wr.msg))
 	return rc
 
 def send_req(wr):
@@ -514,7 +515,7 @@ def send_req(wr):
 	# non-blocking send
 	rc = defw_send_req(wr.remote_uuid,
 					  wr.blk_uuid,
-					  yaml.dump(wr.msg))
+					  attach_encode(wr.msg))
 
 	if rc:
 		raise DEFwCommError(f"Sending failed with {defw_rc2str(rc)}, " \

--- a/python/infra/defw_workers.py
+++ b/python/infra/defw_workers.py
@@ -55,7 +55,9 @@ class WorkerEvent:
 		else:
 			self.msg_yaml = None
 			if msg:
-				self.msg_yaml = attach_load(msg)
+				# uuid identifies the sending agent, which the RMA
+				# path needs in order to read attachments back
+				self.msg_yaml = attach_load(msg, uuid)
 		stack_trace_str = "".join(traceback.format_stack())
 		logging.defw_stacktrace(
 			f"workerEvent generated from:\n{stack_trace_str}"
@@ -505,7 +507,7 @@ def put_connect_complete(status, uuid_str):
 def send_rsp(wr):
 	rc = defw_send_rsp(wr.remote_uuid,
 					  wr.blk_uuid,
-					  attach_encode(wr.msg))
+					  attach_encode(wr.msg, wr.blk_uuid))
 	return rc
 
 def send_req(wr):
@@ -515,7 +517,7 @@ def send_req(wr):
 	# non-blocking send
 	rc = defw_send_req(wr.remote_uuid,
 					  wr.blk_uuid,
-					  attach_encode(wr.msg))
+					  attach_encode(wr.msg, wr.blk_uuid))
 
 	if rc:
 		raise DEFwCommError(f"Sending failed with {defw_rc2str(rc)}, " \

--- a/python/infra/defw_workers.py
+++ b/python/infra/defw_workers.py
@@ -8,7 +8,7 @@ from defw import client_agents, service_agents, \
 				active_client_agents, active_service_agents, \
 				me, preferences, service_apis
 from defw_util import print_thread_stack_trace_to_logger
-from defw_attachments import attach_encode, attach_load
+from defw_attachments import attach_encode, attach_load, attach_discard
 import defw
 
 from collections import deque
@@ -505,9 +505,14 @@ def put_connect_complete(status, uuid_str):
 	logging.defw_worker("Putting connect complete")
 
 def send_rsp(wr):
-	rc = defw_send_rsp(wr.remote_uuid,
-					  wr.blk_uuid,
-					  attach_encode(wr.msg, wr.blk_uuid))
+	# published collects the payloads left in our memory for the peer to
+	# read; if the message never goes out, nobody will ever acknowledge
+	# them, so release them here rather than pinning them until shutdown
+	published = []
+	msg = attach_encode(wr.msg, wr.blk_uuid, published=published)
+	rc = defw_send_rsp(wr.remote_uuid, wr.blk_uuid, msg)
+	if rc and published:
+		attach_discard(published)
 	return rc
 
 def send_req(wr):
@@ -515,11 +520,13 @@ def send_req(wr):
 		worker_thread.add_work_request(wr)
 
 	# non-blocking send
-	rc = defw_send_req(wr.remote_uuid,
-					  wr.blk_uuid,
-					  attach_encode(wr.msg, wr.blk_uuid))
+	published = []
+	msg = attach_encode(wr.msg, wr.blk_uuid, published=published)
+	rc = defw_send_req(wr.remote_uuid, wr.blk_uuid, msg)
 
 	if rc:
+		if published:
+			attach_discard(published)
 		raise DEFwCommError(f"Sending failed with {defw_rc2str(rc)}, " \
 							f"{wr.remote_uuid}, {wr.blk_uuid}")
 

--- a/src/defw_agent.h
+++ b/src/defw_agent.h
@@ -8,6 +8,11 @@
 #define MAX_NUM_AGENTS		1024
 #define HB_TO			2
 
+/* "handle:key:addr:len" -- four unsigned 64-bit values in decimal, three
+ * separators and a terminator, rounded up.
+ */
+#define DEFW_RMA_DESC_STR_LEN	96
+
 #define DEFW_AGENT_STATE_ALIVE (1 << 0)
 #define DEFW_AGENT_CNTRL_CHANNEL_CONNECTED (1 << 1)
 #define DEFW_AGENT_RPC_CHANNEL_CONNECTED (1 << 2)
@@ -186,6 +191,49 @@ int defw_agent_uuid_compare(char *agent_id1, char *agent_id2);
  */
 defw_rc_t defw_send_req(char *dst_uuid, char *blk_uuid, char *yaml);
 defw_rc_t defw_send_rsp(char *dst_uuid, char *blk_uuid, char *yaml);
+
+/*
+ * Large binary payloads (RMA)
+ *
+ * These three carry an RPC's bulk data off the YAML message and onto the
+ * fabric. The sender publishes a buffer, puts the returned descriptor in the
+ * message in place of the data, and the receiver fetches it back. The
+ * registration is released when the fetch acknowledges it, so a published
+ * buffer must always be either fetched or abandoned at shutdown.
+ *
+ * Sizes are unsigned long long rather than uint64_t because SWIG wraps a
+ * uint64_t argument as an opaque pointer object instead of a Python integer.
+ *
+ * defw_rma_available
+ *	Whether bulk data can travel by RMA to the agent with this block uuid:
+ *	the local endpoint must be RMA capable and the peer must be reachable
+ *	over the fabric. Returns 0 when it cannot, and the caller should keep
+ *	the payload inline.
+ *
+ * defw_rma_publish
+ *	Register a copy of the buffer for the peer to read. Returns the
+ *	descriptor as "handle:key:addr:len"; it is text because the message it
+ *	is about to be written into is text, and the fields are split back
+ *	apart by the caller. The copy means the source buffer needs no
+ *	lifetime guarantee.
+ *
+ * defw_rma_fetch
+ *	Read a published region from the agent with this block uuid and return
+ *	it as bytes, acknowledging the transfer so the peer can deregister.
+ *
+ * defw_rma_discard
+ *	Drop a published region that will never be fetched, which is how the
+ *	sender unwinds when it fails partway through publishing a message's
+ *	payloads and falls back to sending them inline.
+ */
+int defw_rma_available(char *blk_uuid);
+defw_rc_t defw_rma_publish(const void *rma_src, size_t rma_srclen,
+			   char **rma_desc);
+defw_rc_t defw_rma_discard(unsigned long long handle);
+defw_rc_t defw_rma_fetch(char *blk_uuid, unsigned long long handle,
+			 unsigned long long key, unsigned long long addr,
+			 unsigned long long len, char **rma_buf,
+			 size_t *rma_len);
 
 static inline defw_agent_uuid_t *defw_get_agent_uuid_raw(defw_agent_blk_t *agent)
 {

--- a/src/defw_common.h
+++ b/src/defw_common.h
@@ -25,8 +25,12 @@
  * address, so its size changed. Old and new builds are intentionally
  * incompatible (the header version check rejects a mismatched peer before
  * its differently-sized session body can be misread).
+ * Bumped to 4: EN_MSG_TYPE_RMA_ACK was added. A build without it would
+ * discard the acknowledgement as an unknown message type and silently leak
+ * the sender's memory registration, so peers are made to disagree on the
+ * version instead and fail the check outright.
  */
-#define DEFW_VERSION_NUMBER		 3
+#define DEFW_VERSION_NUMBER		 4
 
 #define MAX_STR_LEN			1024
 #define MAX_SHORT_STR_LEN		128

--- a/src/defw_listener.c
+++ b/src/defw_listener.c
@@ -54,6 +54,7 @@ static defw_rc_t process_msg_unknown(char *msg, defw_agent_blk_t *agent);
 static defw_rc_t process_msg_hb(char *msg, defw_agent_blk_t *agent);
 static defw_rc_t process_msg_get_num_agents(char *msg, defw_agent_blk_t *agent);
 static defw_rc_t process_msg_session_info(char *msg, defw_agent_blk_t *agent);
+static defw_rc_t process_msg_rma_ack(char *msg, defw_agent_blk_t *agent);
 
 static defw_msg_process_fn_t msg_process_tbl[EN_MSG_TYPE_MAX] = {
 	[EN_MSG_TYPE_HB] = process_msg_hb,
@@ -62,7 +63,29 @@ static defw_msg_process_fn_t msg_process_tbl[EN_MSG_TYPE_MAX] = {
 	[EN_MSG_TYPE_PY_RESPONSE] = process_msg_unknown,
 	[EN_MSG_TYPE_PY_EVENT] = process_msg_unknown,
 	[EN_MSG_TYPE_SESSION_INFO] = process_msg_session_info,
+	[EN_MSG_TYPE_RMA_ACK] = process_msg_rma_ack,
 };
+
+/*
+ * A peer has finished reading a region we registered for it, so the
+ * registration can go. This is handled entirely in C: the acknowledgement
+ * exists to end the lifetime of a memory registration, which the Python layer
+ * knows nothing about.
+ */
+static defw_rc_t process_msg_rma_ack(char *msg, defw_agent_blk_t *agent)
+{
+	defw_msg_rma_ack_t *ack = (defw_msg_rma_ack_t *)msg;
+	uint64_t handle;
+
+	(void)agent;
+
+	handle = ((uint64_t)ntohl(ack->handle_hi) << 32) |
+		 (uint64_t)ntohl(ack->handle_lo);
+
+	PDEBUG("RMA ack received for handle %lu", (unsigned long)handle);
+
+	return defw_transport_ofi_mr_release(handle);
+}
 
 defw_rc_t defw_register_agent_update_notification_cb(defw_agent_update_cb cb)
 {

--- a/src/defw_message.h
+++ b/src/defw_message.h
@@ -22,6 +22,7 @@ typedef enum {
 	EN_MSG_TYPE_PY_REQUEST,
 	EN_MSG_TYPE_PY_RESPONSE,
 	EN_MSG_TYPE_PY_EVENT,
+	EN_MSG_TYPE_RMA_ACK,
 	EN_MSG_TYPE_MAX
 } defw_msg_type_t;
 
@@ -61,5 +62,16 @@ typedef struct defw_msg_session_s {
 typedef struct defw_msg_num_agents_query_s {
 	int num_agents;
 } defw_msg_num_agents_query_t;
+
+/* Acknowledgement that a peer has finished reading a memory region we exposed
+ * for RMA, so the registration can be dropped. The handle is the registration
+ * id the reader was given in the message that advertised the region; it is
+ * split into two 32-bit halves because DEFw stamps wire integers with htonl
+ * and there is no portable 64-bit equivalent.
+ */
+typedef struct defw_msg_rma_ack_s {
+	unsigned int handle_hi;
+	unsigned int handle_lo;
+} defw_msg_rma_ack_t;
 
 #endif /* DEFW_MESSAGE_H */

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include "defw_common.h"
 #include "defw_message.h"
 #include "defw_agent.h"
@@ -120,6 +121,54 @@ defw_rc_t defw_transport_ofi_local_addr(void *buf, size_t *len);
  */
 defw_rc_t defw_transport_ofi_av_insert(const void *addr, size_t addrlen,
 				       uint64_t *fi_addr_out);
+
+/*
+ * Description of a memory region this process has made available for a peer to
+ * fi_read. key/addr/len are what the peer needs and are the only fields that
+ * travel on the wire; handle is a local registration id used to release the
+ * region once the peer acknowledges the transfer.
+ *
+ * addr is deliberately computed by the registering side: whether a peer must
+ * name the region by its virtual address or by an offset from its start
+ * depends on the memory-registration mode the provider negotiated (the tcp
+ * provider requires neither FI_MR_VIRT_ADDR nor FI_MR_PROV_KEY and so uses
+ * offsets, while an RDMA NIC provider typically wants the virtual address).
+ * Resolving that here keeps the reader free of any provider knowledge.
+ */
+typedef struct defw_rma_desc_s {
+	uint64_t handle; /* local registration id; not sent to the peer */
+	uint64_t key;    /* remote key the peer passes to fi_read */
+	uint64_t addr;   /* remote address: virtual address or offset */
+	uint64_t len;    /* length of the region in bytes */
+} defw_rma_desc_t;
+
+/* True when the active OFI endpoint can serve fi_read (the provider offered
+ * FI_RMA and DEFw can satisfy its registration requirements). Large payloads
+ * fall back to an inline transfer when this is false.
+ */
+bool defw_transport_ofi_rma_capable(void);
+
+/* Register buf/len so a peer can fi_read it, filling in desc. The caller keeps
+ * ownership of buf and must keep it alive and unmodified until the matching
+ * defw_transport_ofi_mr_release().
+ */
+defw_rc_t defw_transport_ofi_mr_reg(const void *buf, size_t len,
+				    defw_rma_desc_t *desc);
+
+/* As defw_transport_ofi_mr_reg, but copies buf into a region owned by the
+ * transport, which is freed on release. This costs one copy and in exchange
+ * the caller's buffer needs no lifetime guarantee at all -- the useful trade
+ * when the source is a Python object that would otherwise have to be kept
+ * referenced until the peer's acknowledgement arrives.
+ */
+defw_rc_t defw_transport_ofi_mr_reg_copy(const void *buf, size_t len,
+					 defw_rma_desc_t *desc);
+
+/* Deregister a region registered above and free it if the transport owns it.
+ * Returns EN_DEFW_RC_FAIL for an unknown handle (double release, or a handle
+ * from a previous endpoint).
+ */
+defw_rc_t defw_transport_ofi_mr_release(uint64_t handle);
 
 /* Dispatch a framed DEFw message received as a single [header][body] buffer
  * (the OFI receive path), as opposed to a streamed socket read. Validates the

--- a/src/defw_transport.h
+++ b/src/defw_transport.h
@@ -170,6 +170,13 @@ defw_rc_t defw_transport_ofi_mr_reg_copy(const void *buf, size_t len,
  */
 defw_rc_t defw_transport_ofi_mr_release(uint64_t handle);
 
+/* Read len bytes into buf from a region a peer registered and advertised:
+ * fi_addr is the peer (as cached in its agent block), and key/addr are the
+ * descriptor fields it sent. Blocks until the read completes.
+ */
+defw_rc_t defw_transport_ofi_rma_read(uint64_t fi_addr, uint64_t key,
+				      uint64_t addr, void *buf, size_t len);
+
 /* Dispatch a framed DEFw message received as a single [header][body] buffer
  * (the OFI receive path), as opposed to a streamed socket read. Validates the
  * header, finds the sending agent by uuid, and runs the registered handler.

--- a/src/defw_transport_ofi.c
+++ b/src/defw_transport_ofi.c
@@ -80,6 +80,7 @@ typedef struct defw_ofi_state_s {
 	pthread_mutex_t      send_lock;  /* one outstanding send at a time */
 	struct fi_context    send_ctx;
 	bool                 up;
+	bool                 rma_capable; /* provider offers FI_RMA (fi_read) */
 } defw_ofi_state_t;
 
 static defw_ofi_state_t g_ofi;
@@ -282,7 +283,6 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 	 * most providers require a per-operation context object.
 	 */
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->threading = FI_THREAD_SAFE;
 	if (provider && strlen(provider)) {
@@ -294,7 +294,23 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		}
 	}
 
+	/* Prefer an RMA-capable endpoint so large payloads can move by fi_read
+	 * (phase 3). Some providers (e.g. sm2) do not offer FI_RMA, so fall back
+	 * to message-only; attachments then stream over TCP instead.
+	 */
+	hints->caps = FI_MSG | FI_RMA | FI_READ | FI_REMOTE_READ;
+	hints->domain_attr->mr_mode = FI_MR_VIRT_ADDR | FI_MR_ALLOCATED |
+				      FI_MR_PROV_KEY;
 	ret = fi_getinfo(DEFW_OFI_VERSION, NULL, NULL, 0, hints, &g_ofi.info);
+	if (ret == 0) {
+		g_ofi.rma_capable = true;
+	} else {
+		hints->caps = FI_MSG;
+		hints->domain_attr->mr_mode = 0;
+		ret = fi_getinfo(DEFW_OFI_VERSION, NULL, NULL, 0, hints,
+				 &g_ofi.info);
+		g_ofi.rma_capable = false;
+	}
 	fi_freeinfo(hints);
 	if (ret) {
 		PERROR("fi_getinfo failed: %s", fi_strerror(-ret));
@@ -302,7 +318,9 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		return EN_DEFW_RC_FAIL;
 	}
 
-	PMSG("OFI provider selected: %s", g_ofi.info->fabric_attr->prov_name);
+	PMSG("OFI provider selected: %s (rma=%s)",
+	     g_ofi.info->fabric_attr->prov_name,
+	     g_ofi.rma_capable ? "yes" : "no");
 
 	ret = fi_fabric(g_ofi.info->fabric_attr, &g_ofi.fabric, NULL);
 	if (ret) {

--- a/src/defw_transport_ofi.c
+++ b/src/defw_transport_ofi.c
@@ -10,6 +10,7 @@
 #include "defw_agent.h"
 #include "defw_common.h"
 #include "defw_global.h"
+#include "defw_list.h"
 #include "defw_print.h"
 
 /*
@@ -39,6 +40,7 @@
 #include <rdma/fi_eq.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>
 
 /* Minimum libfabric API version DEFw targets. The container ships 2.3.1. */
@@ -56,12 +58,33 @@
 /* progress-thread CQ poll timeout (ms); short enough to notice shutdown */
 #define DEFW_OFI_PROGRESS_TIMEOUT_MS	1000
 
+/* Set DEFW_OFI_RMA_SELFTEST=1 to run a loopback fi_read against our own
+ * endpoint at startup. Diagnostic only, and off by default.
+ */
+#define DEFW_OFI_RMA_SELFTEST_ENV	"DEFW_OFI_RMA_SELFTEST"
+#define DEFW_OFI_SELFTEST_LEN		(64 * 1024)
+
 /* A posted receive buffer. fi_context MUST be first so a completion's
  * op_context (which points at it) casts straight back to the buffer.
  */
 struct ofi_recv_buf {
 	struct fi_context context;
 	unsigned char     data[DEFW_OFI_RECV_BUF_SIZE];
+};
+
+/* A memory region currently exposed for a peer to fi_read. Registrations are
+ * tracked here rather than handed out as pointers so that the rest of DEFw
+ * (ultimately the Python layer, across a text message) can refer to one by an
+ * opaque integer handle, and so a stale or duplicated release is rejected
+ * instead of dereferencing freed memory.
+ */
+struct ofi_mr_entry {
+	struct dlist_entry entry;
+	uint64_t           handle;
+	struct fid_mr     *mr;
+	void              *buf;
+	size_t             len;
+	bool               owned; /* buf was copied by us, so free it */
 };
 
 typedef struct defw_ofi_state_s {
@@ -81,6 +104,11 @@ typedef struct defw_ofi_state_s {
 	struct fi_context    send_ctx;
 	bool                 up;
 	bool                 rma_capable; /* provider offers FI_RMA (fi_read) */
+	int                  mr_mode;    /* registration mode the provider needs */
+	struct dlist_entry   mr_list;    /* registered regions (ofi_mr_entry) */
+	pthread_mutex_t      mr_lock;
+	uint64_t             mr_next_handle;
+	uint64_t             mr_next_key;
 } defw_ofi_state_t;
 
 static defw_ofi_state_t g_ofi;
@@ -227,8 +255,266 @@ static void *ofi_progress_thread(void *arg)
 	return NULL;
 }
 
+/*
+ * Memory registration for the RMA rendezvous.
+ *
+ * A process that wants to hand a peer a large payload registers it here and
+ * advertises the resulting {key, addr, len}; the peer issues an fi_read and
+ * acknowledges, at which point the region is released.
+ *
+ * Two provider behaviors have to be absorbed here so that no caller (and in
+ * particular no peer) has to reason about them:
+ *
+ *   - Key allocation. When the provider requires FI_MR_PROV_KEY it invents the
+ *     key and ignores what we asked for; otherwise the key is ours to choose
+ *     and must be unique among our live registrations. Passing a fresh key
+ *     from a counter and then reading back fi_mr_key() is correct either way.
+ *     A collision is not silent: fi_mr_reg fails with FI_ENOKEY.
+ *
+ *   - Region addressing. When the provider requires FI_MR_VIRT_ADDR the peer
+ *     names the region by our virtual address; otherwise by an offset from the
+ *     start of the region. We resolve that into desc->addr at registration.
+ */
+static defw_rc_t ofi_mr_reg_common(const void *buf, size_t len, bool copy,
+				   defw_rma_desc_t *desc)
+{
+	struct ofi_mr_entry *e;
+	void *region;
+	uint64_t key;
+	int ret;
+
+	if (!buf || !len || !desc)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	if (!g_ofi.up || !g_ofi.rma_capable)
+		return EN_DEFW_RC_FAIL;
+
+	e = calloc(1, sizeof(*e));
+	if (!e)
+		return EN_DEFW_RC_OOM;
+
+	if (copy) {
+		region = malloc(len);
+		if (!region) {
+			free(e);
+			return EN_DEFW_RC_OOM;
+		}
+		memcpy(region, buf, len);
+	} else {
+		region = (void *)buf;
+	}
+
+	pthread_mutex_lock(&g_ofi.mr_lock);
+
+	key = g_ofi.mr_next_key++;
+	ret = fi_mr_reg(g_ofi.domain, region, len, FI_REMOTE_READ, 0, key, 0,
+			&e->mr, NULL);
+	if (ret) {
+		pthread_mutex_unlock(&g_ofi.mr_lock);
+		PERROR("fi_mr_reg failed for %zu bytes: %s", len,
+		       fi_strerror(-ret));
+		if (copy)
+			free(region);
+		free(e);
+		return EN_DEFW_RC_FAIL;
+	}
+
+	e->handle = g_ofi.mr_next_handle++;
+	e->buf = region;
+	e->len = len;
+	e->owned = copy;
+	dlist_insert_tail(&e->entry, &g_ofi.mr_list);
+
+	desc->handle = e->handle;
+	desc->key = fi_mr_key(e->mr);
+	desc->addr = (g_ofi.mr_mode & FI_MR_VIRT_ADDR) ?
+		     (uint64_t)(uintptr_t)region : 0;
+	desc->len = len;
+
+	pthread_mutex_unlock(&g_ofi.mr_lock);
+
+	PDEBUG("OFI MR registered: handle=%lu key=0x%lx addr=0x%lx len=%zu%s",
+	       (unsigned long)desc->handle, (unsigned long)desc->key,
+	       (unsigned long)desc->addr, len, copy ? " (copied)" : "");
+
+	return EN_DEFW_RC_OK;
+}
+
+defw_rc_t defw_transport_ofi_mr_reg(const void *buf, size_t len,
+				    defw_rma_desc_t *desc)
+{
+	return ofi_mr_reg_common(buf, len, false, desc);
+}
+
+defw_rc_t defw_transport_ofi_mr_reg_copy(const void *buf, size_t len,
+					 defw_rma_desc_t *desc)
+{
+	return ofi_mr_reg_common(buf, len, true, desc);
+}
+
+defw_rc_t defw_transport_ofi_mr_release(uint64_t handle)
+{
+	struct ofi_mr_entry *e, *found = NULL;
+	struct dlist_entry *tmp;
+
+	if (!handle || !g_ofi.mr_list.next)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	pthread_mutex_lock(&g_ofi.mr_lock);
+	dlist_foreach_container_safe(&g_ofi.mr_list, struct ofi_mr_entry,
+				     e, entry, tmp) {
+		if (e->handle == handle) {
+			dlist_remove(&e->entry);
+			found = e;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&g_ofi.mr_lock);
+
+	if (!found) {
+		PERROR("OFI MR release: unknown handle %lu",
+		       (unsigned long)handle);
+		return EN_DEFW_RC_FAIL;
+	}
+
+	fi_close(&found->mr->fid);
+	if (found->owned)
+		free(found->buf);
+	PDEBUG("OFI MR released: handle=%lu", (unsigned long)handle);
+	free(found);
+
+	return EN_DEFW_RC_OK;
+}
+
+/* Drop every registration still outstanding. Called at teardown so a peer that
+ * died before acknowledging a transfer cannot leave a region registered.
+ */
+static void ofi_mr_release_all(void)
+{
+	struct ofi_mr_entry *e;
+	struct dlist_entry *tmp;
+	int n = 0;
+
+	if (!g_ofi.mr_list.next)
+		return;
+
+	pthread_mutex_lock(&g_ofi.mr_lock);
+	dlist_foreach_container_safe(&g_ofi.mr_list, struct ofi_mr_entry,
+				     e, entry, tmp) {
+		dlist_remove(&e->entry);
+		fi_close(&e->mr->fid);
+		if (e->owned)
+			free(e->buf);
+		free(e);
+		n++;
+	}
+	pthread_mutex_unlock(&g_ofi.mr_lock);
+
+	if (n)
+		PDEBUG("OFI released %d outstanding memory region(s)", n);
+}
+
+bool defw_transport_ofi_rma_capable(void)
+{
+	return g_ofi.up && g_ofi.rma_capable;
+}
+
+/*
+ * Prove the RMA path works before anything depends on it: register a buffer,
+ * fi_read it back out of ourselves through the fabric, and compare. This
+ * exercises exactly what a peer will do, so a provider whose registration or
+ * addressing rules we got wrong fails here with a clear message instead of
+ * corrupting a payload later.
+ *
+ * Runs during init, before the progress thread starts and before any peer is
+ * known, so nothing else is touching the endpoint or the transmit CQ.
+ */
+static void ofi_rma_selftest(void)
+{
+	struct fi_cq_msg_entry entry;
+	struct fi_context ctx;
+	defw_rma_desc_t desc;
+	fi_addr_t self = FI_ADDR_UNSPEC;
+	unsigned char *src, *dst;
+	size_t len = DEFW_OFI_SELFTEST_LEN;
+	size_t i;
+	ssize_t ret;
+
+	if (!g_ofi.rma_capable) {
+		PMSG("OFI RMA selftest: skipped, provider %s is not RMA capable",
+		     g_ofi.info->fabric_attr->prov_name);
+		return;
+	}
+
+	src = malloc(len);
+	dst = malloc(len);
+	if (!src || !dst) {
+		PERROR("OFI RMA selftest: out of memory");
+		goto out;
+	}
+
+	for (i = 0; i < len; i++)
+		src[i] = (unsigned char)(i & 0xff);
+	memset(dst, 0, len);
+
+	/* read from ourselves: our own endpoint name is a perfectly good peer */
+	if (fi_av_insert(g_ofi.av, g_ofi.local_addr, 1, &self, 0, NULL) != 1) {
+		PERROR("OFI RMA selftest: fi_av_insert(self) failed");
+		goto out;
+	}
+
+	if (defw_transport_ofi_mr_reg(src, len, &desc) != EN_DEFW_RC_OK)
+		goto out_av;
+
+	/* the local destination needs no descriptor: DEFw only claims RMA
+	 * capability for providers that do not require FI_MR_LOCAL
+	 */
+	do {
+		ret = fi_read(g_ofi.ep, dst, len, NULL, self, desc.addr,
+			      desc.key, &ctx);
+		if (ret == -FI_EAGAIN)
+			fi_cq_read(g_ofi.tx_cq, &entry, 1);
+	} while (ret == -FI_EAGAIN);
+
+	if (ret) {
+		PERROR("OFI RMA selftest: fi_read failed: %s",
+		       fi_strerror((int)-ret));
+		goto out_mr;
+	}
+
+	ret = fi_cq_sread(g_ofi.tx_cq, &entry, 1, NULL,
+			  DEFW_OFI_SEND_TIMEOUT_MS);
+	if (ret == -FI_EAVAIL) {
+		struct fi_cq_err_entry err = {0};
+
+		fi_cq_readerr(g_ofi.tx_cq, &err, 0);
+		PERROR("OFI RMA selftest: read completion error: %s",
+		       fi_cq_strerror(g_ofi.tx_cq, err.prov_errno,
+				      err.err_data, NULL, 0));
+	} else if (ret != 1) {
+		PERROR("OFI RMA selftest: no read completion: %s",
+		       fi_strerror((int)-ret));
+	} else if (memcmp(src, dst, len)) {
+		PERROR("OFI RMA selftest: data mismatch after fi_read");
+	} else {
+		PMSG("OFI RMA selftest: passed, %zu bytes read over %s (key=0x%lx addr=0x%lx)",
+		     len, g_ofi.info->fabric_attr->prov_name,
+		     (unsigned long)desc.key, (unsigned long)desc.addr);
+	}
+
+out_mr:
+	defw_transport_ofi_mr_release(desc.handle);
+out_av:
+	fi_av_remove(g_ofi.av, &self, 1, 0);
+out:
+	free(src);
+	free(dst);
+}
+
 static void ofi_fini(void)
 {
+	ofi_mr_release_all();
+
 	if (g_ofi.progress_run) {
 		g_ofi.progress_run = false;
 		pthread_join(g_ofi.progress_thread, NULL);
@@ -249,6 +535,7 @@ static void ofi_fini(void)
 		fi_freeinfo(g_ofi.info);
 	free(g_ofi.recv_bufs);
 	pthread_mutex_destroy(&g_ofi.send_lock);
+	pthread_mutex_destroy(&g_ofi.mr_lock);
 	memset(&g_ofi, 0, sizeof(g_ofi));
 }
 
@@ -272,10 +559,16 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 	memset(&g_ofi, 0, sizeof(g_ofi));
 	memset(&av_attr, 0, sizeof(av_attr));
 	pthread_mutex_init(&g_ofi.send_lock, NULL);
+	pthread_mutex_init(&g_ofi.mr_lock, NULL);
+	dlist_init(&g_ofi.mr_list);
+	/* handle and key 0 are reserved as "no registration" */
+	g_ofi.mr_next_handle = 1;
+	g_ofi.mr_next_key = 1;
 
 	hints = fi_allocinfo();
 	if (!hints) {
 		pthread_mutex_destroy(&g_ofi.send_lock);
+		pthread_mutex_destroy(&g_ofi.mr_lock);
 		return EN_DEFW_RC_OOM;
 	}
 
@@ -290,6 +583,7 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 		if (!hints->fabric_attr->prov_name) {
 			fi_freeinfo(hints);
 			pthread_mutex_destroy(&g_ofi.send_lock);
+			pthread_mutex_destroy(&g_ofi.mr_lock);
 			return EN_DEFW_RC_OOM;
 		}
 	}
@@ -315,12 +609,31 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 	if (ret) {
 		PERROR("fi_getinfo failed: %s", fi_strerror(-ret));
 		pthread_mutex_destroy(&g_ofi.send_lock);
+		pthread_mutex_destroy(&g_ofi.mr_lock);
 		return EN_DEFW_RC_FAIL;
 	}
 
-	PMSG("OFI provider selected: %s (rma=%s)",
+	/* The provider answers with the registration rules it actually needs,
+	 * which are usually fewer than we offered (the tcp provider asks for
+	 * none at all). Remember them: they decide how a region is named to a
+	 * peer, and whether we are able to serve RMA at all.
+	 */
+	g_ofi.mr_mode = g_ofi.info->domain_attr->mr_mode;
+
+	/* FI_MR_LOCAL means even the local buffer of an fi_read must be
+	 * registered and passed as a descriptor. DEFw does not do that yet, so
+	 * rather than issue reads the provider will reject, drop back to the
+	 * inline payload path and say so.
+	 */
+	if (g_ofi.rma_capable && (g_ofi.mr_mode & FI_MR_LOCAL)) {
+		PMSG("OFI provider %s requires FI_MR_LOCAL; RMA disabled, large payloads stay inline",
+		     g_ofi.info->fabric_attr->prov_name);
+		g_ofi.rma_capable = false;
+	}
+
+	PMSG("OFI provider selected: %s (rma=%s mr_mode=0x%x)",
 	     g_ofi.info->fabric_attr->prov_name,
-	     g_ofi.rma_capable ? "yes" : "no");
+	     g_ofi.rma_capable ? "yes" : "no", g_ofi.mr_mode);
 
 	ret = fi_fabric(g_ofi.info->fabric_attr, &g_ofi.fabric, NULL);
 	if (ret) {
@@ -417,6 +730,9 @@ defw_rc_t defw_transport_ofi_init(const char *provider)
 
 	g_ofi.up = true;
 
+	if (getenv(DEFW_OFI_RMA_SELFTEST_ENV))
+		ofi_rma_selftest();
+
 	/* start draining receive completions */
 	g_ofi.progress_run = true;
 	if (pthread_create(&g_ofi.progress_thread, NULL,
@@ -499,6 +815,35 @@ defw_rc_t defw_transport_ofi_av_insert(const void *addr, size_t addrlen,
 	(void)addr;
 	(void)addrlen;
 	(void)fi_addr_out;
+	return EN_DEFW_RC_FAIL;
+}
+
+bool defw_transport_ofi_rma_capable(void)
+{
+	return false;
+}
+
+defw_rc_t defw_transport_ofi_mr_reg(const void *buf, size_t len,
+				    defw_rma_desc_t *desc)
+{
+	(void)buf;
+	(void)len;
+	(void)desc;
+	return EN_DEFW_RC_FAIL;
+}
+
+defw_rc_t defw_transport_ofi_mr_reg_copy(const void *buf, size_t len,
+					 defw_rma_desc_t *desc)
+{
+	(void)buf;
+	(void)len;
+	(void)desc;
+	return EN_DEFW_RC_FAIL;
+}
+
+defw_rc_t defw_transport_ofi_mr_release(uint64_t handle)
+{
+	(void)handle;
 	return EN_DEFW_RC_FAIL;
 }
 

--- a/src/defw_transport_ofi.c
+++ b/src/defw_transport_ofi.c
@@ -102,6 +102,7 @@ typedef struct defw_ofi_state_s {
 	volatile bool        progress_run;
 	pthread_mutex_t      send_lock;  /* one outstanding send at a time */
 	struct fi_context    send_ctx;
+	struct fi_context    rma_ctx;
 	bool                 up;
 	bool                 rma_capable; /* provider offers FI_RMA (fi_read) */
 	int                  mr_mode;    /* registration mode the provider needs */
@@ -117,6 +118,30 @@ static ssize_t ofi_post_recv(struct ofi_recv_buf *buf)
 {
 	return fi_recv(g_ofi.ep, buf->data, DEFW_OFI_RECV_BUF_SIZE, NULL,
 		       FI_ADDR_UNSPEC, &buf->context);
+}
+
+/*
+ * Report a failed completion, and return the error entry so the caller can
+ * act on it.
+ *
+ * Both codes are printed on purpose. err.err is libfabric's own reason, and
+ * is the only useful one for a failure the library detects rather than the
+ * provider -- a truncated receive, for instance, sets err.err to FI_ETRUNC
+ * and leaves prov_errno at zero, so reporting the provider code alone renders
+ * a real failure as "Success".
+ */
+static void ofi_report_cq_err(struct fid_cq *cq, const char *what,
+			      struct fi_cq_err_entry *err)
+{
+	memset(err, 0, sizeof(*err));
+
+	if (fi_cq_readerr(cq, err, 0) < 1) {
+		PERROR("%s: failed, but no error entry was available", what);
+		return;
+	}
+
+	PERROR("%s: %s (provider: %s)", what, fi_strerror(err->err),
+	       fi_cq_strerror(cq, err->prov_errno, err->err_data, NULL, 0));
 }
 
 /*
@@ -168,12 +193,9 @@ static defw_rc_t ofi_send_msg(fi_addr_t dst, char *body, size_t bodylen,
 	if (ret == 1) {
 		/* send completed */
 	} else if (ret == -FI_EAVAIL) {
-		struct fi_cq_err_entry err = {0};
+		struct fi_cq_err_entry err;
 
-		fi_cq_readerr(g_ofi.tx_cq, &err, 0);
-		PERROR("OFI send completion error: %s",
-		       fi_cq_strerror(g_ofi.tx_cq, err.prov_errno,
-				      err.err_data, NULL, 0));
+		ofi_report_cq_err(g_ofi.tx_cq, "OFI send completion", &err);
 		rc = EN_DEFW_RC_SOCKET_FAIL;
 	} else if (ret == -FI_EAGAIN) {
 		PERROR("OFI send completion timed out");
@@ -206,6 +228,24 @@ static defw_rc_t ofi_send(defw_agent_blk_t *agent, defw_channel_t ch,
 	    !(agent->state & DEFW_AGENT_OFI_ADDR_VALID))
 		return defw_transport_tcp_ops()->send(agent, ch, buf, len, type);
 
+	/*
+	 * The fabric receive path is eager: the peer has fixed-size buffers
+	 * posted, and a message larger than one of them is truncated on
+	 * arrival, which the sender never sees -- it surfaces at the far end
+	 * as a request that never appears. Send anything that big over TCP
+	 * instead, which is a stream and has no such limit.
+	 *
+	 * A large payload normally travels as an RMA attachment and never
+	 * reaches this test. This is the fallback for when it cannot: a peer
+	 * or provider without RMA, where the payload stays inline in the
+	 * message body.
+	 */
+	if (sizeof(defw_message_hdr_t) + len > DEFW_OFI_RECV_BUF_SIZE) {
+		PDEBUG("message of %zu bytes exceeds the %d byte eager buffer; sending over TCP",
+		       len, DEFW_OFI_RECV_BUF_SIZE);
+		return defw_transport_tcp_ops()->send(agent, ch, buf, len, type);
+	}
+
 	return ofi_send_msg((fi_addr_t)agent->ofi_addr, buf, len, type);
 }
 
@@ -237,12 +277,10 @@ static void *ofi_progress_thread(void *arg)
 		} else if (ret == -FI_EAGAIN) {
 			continue; /* poll timeout; re-check progress_run */
 		} else if (ret == -FI_EAVAIL) {
-			struct fi_cq_err_entry err = {0};
+			struct fi_cq_err_entry err;
 
-			fi_cq_readerr(g_ofi.rx_cq, &err, 0);
-			PERROR("OFI recv completion error: %s",
-			       fi_cq_strerror(g_ofi.rx_cq, err.prov_errno,
-					      err.err_data, NULL, 0));
+			ofi_report_cq_err(g_ofi.rx_cq, "OFI recv completion",
+					  &err);
 			if (err.op_context)
 				ofi_post_recv(err.op_context);
 		} else {
@@ -420,6 +458,77 @@ bool defw_transport_ofi_rma_capable(void)
 }
 
 /*
+ * Pull a peer's registered region into buf.
+ *
+ * The transmit CQ carries one completion at a time by construction:
+ * ofi_send_msg issues a send and then waits for its own completion, so a read
+ * that did not hold the same lock would consume the send's completion, or have
+ * its own consumed. Holding send_lock across issue-and-wait keeps that
+ * invariant, and costs nothing here because the peer serves the read from its
+ * own progress engine rather than from anything we hold.
+ *
+ * The context lives in the transport state rather than on the stack: if the
+ * wait times out the operation is still outstanding, and the provider may
+ * write the completion afterwards.
+ */
+defw_rc_t defw_transport_ofi_rma_read(uint64_t fi_addr, uint64_t key,
+				      uint64_t addr, void *buf, size_t len)
+{
+	struct fi_cq_msg_entry entry;
+	defw_rc_t rc = EN_DEFW_RC_OK;
+	ssize_t ret;
+
+	if (!buf || !len)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	if (!g_ofi.up || !g_ofi.rma_capable)
+		return EN_DEFW_RC_FAIL;
+
+	PDEBUG("OFI RMA read: %zu bytes from fi_addr=%lu key=0x%lx addr=0x%lx",
+	       len, (unsigned long)fi_addr, (unsigned long)key,
+	       (unsigned long)addr);
+
+	pthread_mutex_lock(&g_ofi.send_lock);
+
+	do {
+		ret = fi_read(g_ofi.ep, buf, len, NULL, (fi_addr_t)fi_addr,
+			      addr, key, &g_ofi.rma_ctx);
+		if (ret == -FI_EAGAIN)
+			fi_cq_read(g_ofi.tx_cq, &entry, 1);
+	} while (ret == -FI_EAGAIN);
+
+	if (ret) {
+		PERROR("fi_read failed: %s", fi_strerror((int)-ret));
+		rc = EN_DEFW_RC_SOCKET_FAIL;
+		goto out;
+	}
+
+	ret = fi_cq_sread(g_ofi.tx_cq, &entry, 1, NULL,
+			  DEFW_OFI_SEND_TIMEOUT_MS);
+	if (ret == 1) {
+		/* read completed */
+	} else if (ret == -FI_EAVAIL) {
+		struct fi_cq_err_entry err;
+
+		ofi_report_cq_err(g_ofi.tx_cq, "OFI RMA read completion", &err);
+		rc = EN_DEFW_RC_SOCKET_FAIL;
+	} else if (ret == -FI_EAGAIN) {
+		PERROR("OFI RMA read timed out after %d ms",
+		       DEFW_OFI_SEND_TIMEOUT_MS);
+		rc = EN_DEFW_RC_TIMEOUT;
+	} else {
+		PERROR("fi_cq_sread(tx) failed after fi_read: %s",
+		       fi_strerror((int)-ret));
+		rc = EN_DEFW_RC_SOCKET_FAIL;
+	}
+
+out:
+	pthread_mutex_unlock(&g_ofi.send_lock);
+
+	return rc;
+}
+
+/*
  * Prove the RMA path works before anything depends on it: register a buffer,
  * fi_read it back out of ourselves through the fabric, and compare. This
  * exercises exactly what a peer will do, so a provider whose registration or
@@ -431,14 +540,11 @@ bool defw_transport_ofi_rma_capable(void)
  */
 static void ofi_rma_selftest(void)
 {
-	struct fi_cq_msg_entry entry;
-	struct fi_context ctx;
 	defw_rma_desc_t desc;
 	fi_addr_t self = FI_ADDR_UNSPEC;
 	unsigned char *src, *dst;
 	size_t len = DEFW_OFI_SELFTEST_LEN;
 	size_t i;
-	ssize_t ret;
 
 	if (!g_ofi.rma_capable) {
 		PMSG("OFI RMA selftest: skipped, provider %s is not RMA capable",
@@ -466,34 +572,12 @@ static void ofi_rma_selftest(void)
 	if (defw_transport_ofi_mr_reg(src, len, &desc) != EN_DEFW_RC_OK)
 		goto out_av;
 
-	/* the local destination needs no descriptor: DEFw only claims RMA
-	 * capability for providers that do not require FI_MR_LOCAL
+	/* deliberately the same call the receive path uses, so this exercises
+	 * the real read rather than a parallel copy of it
 	 */
-	do {
-		ret = fi_read(g_ofi.ep, dst, len, NULL, self, desc.addr,
-			      desc.key, &ctx);
-		if (ret == -FI_EAGAIN)
-			fi_cq_read(g_ofi.tx_cq, &entry, 1);
-	} while (ret == -FI_EAGAIN);
-
-	if (ret) {
-		PERROR("OFI RMA selftest: fi_read failed: %s",
-		       fi_strerror((int)-ret));
-		goto out_mr;
-	}
-
-	ret = fi_cq_sread(g_ofi.tx_cq, &entry, 1, NULL,
-			  DEFW_OFI_SEND_TIMEOUT_MS);
-	if (ret == -FI_EAVAIL) {
-		struct fi_cq_err_entry err = {0};
-
-		fi_cq_readerr(g_ofi.tx_cq, &err, 0);
-		PERROR("OFI RMA selftest: read completion error: %s",
-		       fi_cq_strerror(g_ofi.tx_cq, err.prov_errno,
-				      err.err_data, NULL, 0));
-	} else if (ret != 1) {
-		PERROR("OFI RMA selftest: no read completion: %s",
-		       fi_strerror((int)-ret));
+	if (defw_transport_ofi_rma_read((uint64_t)self, desc.key, desc.addr,
+					dst, len) != EN_DEFW_RC_OK) {
+		PERROR("OFI RMA selftest: read failed");
 	} else if (memcmp(src, dst, len)) {
 		PERROR("OFI RMA selftest: data mismatch after fi_read");
 	} else {
@@ -502,7 +586,6 @@ static void ofi_rma_selftest(void)
 		     (unsigned long)desc.key, (unsigned long)desc.addr);
 	}
 
-out_mr:
 	defw_transport_ofi_mr_release(desc.handle);
 out_av:
 	fi_av_remove(g_ofi.av, &self, 1, 0);
@@ -844,6 +927,17 @@ defw_rc_t defw_transport_ofi_mr_reg_copy(const void *buf, size_t len,
 defw_rc_t defw_transport_ofi_mr_release(uint64_t handle)
 {
 	(void)handle;
+	return EN_DEFW_RC_FAIL;
+}
+
+defw_rc_t defw_transport_ofi_rma_read(uint64_t fi_addr, uint64_t key,
+				      uint64_t addr, void *buf, size_t len)
+{
+	(void)fi_addr;
+	(void)key;
+	(void)addr;
+	(void)buf;
+	(void)len;
 	return EN_DEFW_RC_FAIL;
 }
 

--- a/src/libdefw_agent.c
+++ b/src/libdefw_agent.c
@@ -1024,6 +1024,132 @@ defw_rc_t defw_send_rsp(char *dst_uuid, char *blk_uuid, char *yaml)
 	return defw_send(dst_uuid, blk_uuid, yaml, EN_MSG_TYPE_PY_RESPONSE);
 }
 
+defw_rc_t defw_send_rma_ack(defw_agent_blk_t *agent, uint64_t handle)
+{
+	defw_msg_rma_ack_t msg;
+
+	if (!agent)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	msg.handle_hi = htonl((unsigned int)(handle >> 32));
+	msg.handle_lo = htonl((unsigned int)(handle & 0xffffffff));
+
+	return defw_transport_ops()->send(agent, EN_DEFW_CHANNEL_RPC,
+					  (char *)&msg, sizeof(msg),
+					  EN_MSG_TYPE_RMA_ACK);
+}
+
+int defw_rma_available(char *blk_uuid)
+{
+	defw_agent_blk_t *agent;
+	int available;
+
+	if (!defw_transport_ofi_rma_capable())
+		return 0;
+
+	agent = defw_find_agent_by_blk_uuid(blk_uuid);
+	if (!agent)
+		return 0;
+
+	/* the peer has to be reachable on the fabric: it advertised an OFI
+	 * address in the handshake and we inserted it (phase 1b)
+	 */
+	available = (agent->state & DEFW_AGENT_OFI_ADDR_VALID) ? 1 : 0;
+	defw_release_agent_blk(agent, false);
+
+	return available;
+}
+
+defw_rc_t defw_rma_publish(const void *rma_src, size_t rma_srclen,
+			   char **rma_desc)
+{
+	defw_rma_desc_t desc;
+	defw_rc_t rc;
+	char *out;
+
+	if (!rma_src || !rma_srclen || !rma_desc)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	rc = defw_transport_ofi_mr_reg_copy(rma_src, rma_srclen, &desc);
+	if (rc != EN_DEFW_RC_OK)
+		return rc;
+
+	out = calloc(1, DEFW_RMA_DESC_STR_LEN);
+	if (!out) {
+		defw_transport_ofi_mr_release(desc.handle);
+		return EN_DEFW_RC_OOM;
+	}
+
+	snprintf(out, DEFW_RMA_DESC_STR_LEN, "%llu:%llu:%llu:%llu",
+		 (unsigned long long)desc.handle, (unsigned long long)desc.key,
+		 (unsigned long long)desc.addr, (unsigned long long)desc.len);
+	*rma_desc = out;
+
+	return EN_DEFW_RC_OK;
+}
+
+defw_rc_t defw_rma_discard(unsigned long long handle)
+{
+	return defw_transport_ofi_mr_release((uint64_t)handle);
+}
+
+defw_rc_t defw_rma_fetch(char *blk_uuid, unsigned long long handle,
+			 unsigned long long key, unsigned long long addr,
+			 unsigned long long len, char **rma_buf,
+			 size_t *rma_len)
+{
+	defw_agent_blk_t *agent;
+	defw_rc_t rc;
+	char *buf;
+
+	if (!blk_uuid || !len || !rma_buf || !rma_len)
+		return EN_DEFW_RC_BAD_PARAM;
+
+	agent = defw_find_agent_by_blk_uuid(blk_uuid);
+	if (!agent) {
+		PERROR("RMA fetch: no agent with block uuid %s", blk_uuid);
+		return EN_DEFW_RC_AGENT_NOT_FOUND;
+	}
+
+	if (!(agent->state & DEFW_AGENT_OFI_ADDR_VALID)) {
+		PERROR("RMA fetch: agent %s is not reachable over the fabric",
+		       agent->name);
+		defw_release_agent_blk(agent, false);
+		return EN_DEFW_RC_FAIL;
+	}
+
+	buf = malloc((size_t)len);
+	if (!buf) {
+		defw_release_agent_blk(agent, false);
+		return EN_DEFW_RC_OOM;
+	}
+
+	rc = defw_transport_ofi_rma_read(agent->ofi_addr, key, addr, buf,
+					 (size_t)len);
+	if (rc != EN_DEFW_RC_OK) {
+		free(buf);
+		defw_release_agent_blk(agent, false);
+		return rc;
+	}
+
+	/* The peer keeps the region registered until it hears the read is
+	 * done. A failed acknowledgement is not fatal for this transfer -- we
+	 * have the data -- but it does strand the registration until the peer
+	 * tears its endpoint down, so it is worth saying out loud.
+	 */
+	rc = defw_send_rma_ack(agent, (uint64_t)handle);
+	if (rc != EN_DEFW_RC_OK)
+		PERROR("RMA fetch: could not acknowledge handle %llu: %s",
+		       handle, defw_rc2str(rc));
+
+	defw_release_agent_blk(agent, false);
+
+	*rma_buf = buf;
+	*rma_len = (size_t)len;
+
+	return EN_DEFW_RC_OK;
+}
+
 static
 defw_agent_blk_t *find_agent_blk_by_uuid(defw_agent_uuid_t *id, bool full,
 					struct dlist_entry *list)
@@ -1094,6 +1220,51 @@ defw_find_agent_by_uuid_global(defw_agent_uuid_t *id)
 		agent = defw_find_client_agent_by_uuid(id, true);
 	if (!agent)
 		agent = defw_find_active_client_agent_by_uuid(id, true);
+
+	return agent;
+}
+
+static defw_agent_blk_t *
+find_blk_uuid_in_list(uuid_t blk_uuid, struct dlist_entry *list)
+{
+	struct dlist_entry *tmp;
+	defw_agent_blk_t *agent, *found = NULL;
+
+	dlist_foreach_container_safe(list, defw_agent_blk_t, agent,
+				     entry, tmp) {
+		if (uuid_compare(agent->id.blk_uuid, blk_uuid) == 0) {
+			found = agent;
+			acquire_agent_blk(agent);
+			break;
+		}
+	}
+
+	return found;
+}
+
+/*
+ * The block uuid is assigned locally and is unique to an agent block, so it
+ * identifies a peer on its own. The existing lookups all key on the remote
+ * uuid, which the Python layer is never given; it only ever sees the block
+ * uuid, which is why the RMA fetch needs this one.
+ */
+defw_agent_blk_t *defw_find_agent_by_blk_uuid(char *blk_uuid_str)
+{
+	defw_agent_blk_t *agent;
+	uuid_t blk_uuid;
+
+	if (!blk_uuid_str || uuid_parse(blk_uuid_str, blk_uuid))
+		return NULL;
+
+	MUTEX_LOCK(&agent_array_mutex);
+	agent = find_blk_uuid_in_list(blk_uuid, &agent_active_service_list);
+	if (!agent)
+		agent = find_blk_uuid_in_list(blk_uuid, &agent_service_list);
+	if (!agent)
+		agent = find_blk_uuid_in_list(blk_uuid, &agent_client_list);
+	if (!agent)
+		agent = find_blk_uuid_in_list(blk_uuid, &agent_active_client_list);
+	MUTEX_UNLOCK(&agent_array_mutex);
 
 	return agent;
 }

--- a/src/libdefw_agent.h
+++ b/src/libdefw_agent.h
@@ -79,6 +79,15 @@ defw_rc_t defw_send_hb(defw_agent_blk_t *agent);
 defw_rc_t defw_send_session_info(defw_agent_blk_t *agent, bool rpc_setup);
 defw_agent_blk_t *defw_find_agent_by_uuid_global(defw_agent_uuid_t *id);
 defw_agent_blk_t *defw_find_agent_by_uuid_passive(uuid_t uuid);
+/* Find an agent by the block uuid, which is the identifier the Python layer
+ * is handed for an incoming message and hands back when replying. Returns the
+ * agent with a reference taken, or NULL.
+ */
+defw_agent_blk_t *defw_find_agent_by_blk_uuid(char *blk_uuid_str);
+/* Tell a peer we have finished reading the region it registered under handle,
+ * so it can deregister and release the memory.
+ */
+defw_rc_t defw_send_rma_ack(defw_agent_blk_t *agent, uint64_t handle);
 void defw_move_to_client_list(defw_agent_blk_t *agent);
 void defw_move_to_service_list(defw_agent_blk_t *agent);
 void defw_release_dead_list_agents(void);

--- a/swig_templates/typemap.template
+++ b/swig_templates/typemap.template
@@ -61,6 +61,60 @@
        free(*$1);
 %}
 
+/* Binary payload passed in from python, as a (pointer, length) pair.
+ *
+ * The generic char* mapping cannot be used for this: it produces a
+ * NUL-terminated string, which truncates binary data at the first zero byte.
+ * Matching on the argument names keeps this narrowly scoped to the functions
+ * that take a payload, and takes precedence over the single-argument typemaps
+ * above. The pointer is borrowed from the python bytes object, which the
+ * caller's argument tuple keeps alive for the duration of the call, so there
+ * is nothing to release afterwards.
+ */
+%typemap(in) (const void *rma_src, size_t rma_srclen) %{
+    {
+        char *rma_in_buf = NULL;
+        Py_ssize_t rma_in_len = 0;
+
+        if (PyBytes_AsStringAndSize($input, &rma_in_buf, &rma_in_len) < 0)
+            SWIG_fail;
+        $1 = rma_in_buf;
+        $2 = (size_t)rma_in_len;
+    }
+%}
+
+/* Binary payload returned to python, as a malloc'ed (pointer, length) pair
+ * that becomes a bytes object. Mirrors the char** convention above: the
+ * argout typemap builds the result and the freearg typemap releases the
+ * buffer C allocated.
+ */
+%typemap(in, numinputs=0) (char **rma_buf, size_t *rma_len)
+                          (char *rma_out_buf, size_t rma_out_len) %{
+    rma_out_buf = NULL;
+    rma_out_len = 0;
+    $1 = &rma_out_buf;
+    $2 = &rma_out_len;
+%}
+
+%typemap(argout) (char **rma_buf, size_t *rma_len) (PyObject* obj) %{
+    if (*$1) {
+        obj = PyBytes_FromStringAndSize(*$1, (Py_ssize_t)*$2);
+    } else {
+        obj = Py_None;
+        Py_INCREF(obj);
+    }
+#if SWIG_VERSION >= 40100
+    $result = SWIG_Python_AppendOutput($result, obj, $isvoid);
+#else
+    $result = SWIG_Python_AppendOutput($result, obj);
+#endif
+%}
+
+%typemap(freearg) (char **rma_buf, size_t *rma_len) %{
+    if (*$1)
+       free(*$1);
+%}
+
 /* Allows passing void * to functions. Both this typemap and the one below it
  * work in tandem. The first defines how input void* parameters are
  * handled. We use SWIG_ConvertPtr to take a python object and convert it


### PR DESCRIPTION
Phase 3 of the libfabric transport work: move an RPC's large binary payloads
over the fabric by RMA instead of carrying them inside the message. Builds on
the OFI transport merged in #15.

Application code is unchanged. A service that returns a NumPy array keeps
returning a NumPy array; the framework notices the payload and decides how to
move it.

## How it works

A payload large enough to be worth it is left in the sender's memory and named
in the message by a descriptor. The receiver reads it directly with `fi_read`
and acknowledges, which is what ends the registration's life. Smaller payloads,
and payloads bound for a peer that cannot do RMA, are carried inline as base64
instead. The choice is made per payload, so one message can carry a small array
inline alongside a large one by RMA.

The acknowledgement is a new message type handled entirely in C. It exists only
to release a memory registration, which the Python layer knows nothing about,
so routing it up and back down would only have given the release path more ways
to be missed.

## Commits

| | |
|---|---|
| 3a | RMA-optional endpoint negotiation, so a provider without RMA still works |
| 3b | transparent attachment detection and the inline (eager) path |
| 3c-i | memory registration helpers and the region descriptor |
| 3c-ii | the `fi_read` rendezvous, the acknowledgement, and the Python/C binding |
| 3c-iii | automatic per-payload routing by size |

## Things worth a reviewer's attention

**Providers disagree about how a region is named, and the descriptor absorbs
it.** The tcp provider negotiates `mr_mode = 0`: it requires neither
`FI_MR_VIRT_ADDR` nor `FI_MR_PROV_KEY`, so a peer addresses the region by an
*offset*, not by the sender's virtual address, and the key is ours to choose
rather than the provider's to invent. The registering side resolves both into
the descriptor, so the reading peer needs no provider knowledge. Naming the
region by its virtual address instead fails the read with `ENOENT`.

**A provider requiring `FI_MR_LOCAL` turns RMA off and says so.** That would
additionally need the read's local buffer registered, which is not implemented
here; falling back to inline is correct, just slower. This is the likely
situation on cxi and is where phase 2 will pick it up.

**`uint64_t` is avoided in the SWIG-visible prototypes.** SWIG wraps it as an
opaque pointer object rather than a Python integer. Binary payloads also need
their own typemaps, since the generic `char*` mapping produces a
NUL-terminated string and truncates at the first zero byte.

**Two pre-existing problems are fixed here**, both older than this branch:

- A message too large for the peer's posted receive buffer was truncated on
  arrival with nothing visible to the sender, surfacing at the far end as a
  request that never came. Large payloads now normally travel as attachments
  and never reach that limit, but the inline fallback still can, so an
  oversized message goes over TCP, which is a stream. A 1 MiB payload without
  RMA used to time out and now completes.
- Failed completions were reported with the provider error code alone, which is
  zero for anything libfabric itself detects, so a truncated receive printed as
  `OFI recv completion error: Success`. Both codes are now reported.

**The wire format changed**, so `DEFW_VERSION_NUMBER` is bumped to 4. A build
without the new message type would discard the acknowledgement as unknown and
silently strand the sender's registration; disagreeing on the version is a
better way to find that out.

## Defaults and knobs

RMA is used by default where it is available, so nothing has to be enabled and
no environment variable needs to reach the resmgr and service agents.
`DEFW_RMA_ATTACHMENTS=0` keeps every payload inline, and `DEFW_RMA_THRESHOLD`
moves the 64 KiB crossover (`0` sends everything by RMA, which is how the RMA
path is exercised with small payloads). `DEFW_OFI_RMA_SELFTEST=1` runs a
loopback `fi_read` at startup.

The 64 KiB default is a judgement rather than a measurement: base64 inflates a
payload by a third and the eager receive buffer is 256 KiB, so inline payloads
much above 192 KiB leave the eager path anyway. Worth revisiting with numbers
when a bulk-data path adopts this.

## Testing

Validated in the QFw-SLURM-Cluster container over a real two-process RPC,
round-tripping a 1 MiB complex128 array through a service that returns a
checksum of what it received, so a failure in the request direction is
distinguishable from one in the response direction.

| case | result |
|---|---|
| tcp, no environment set, 1 MiB | RMA engages automatically; read, ack and release in the logs |
| tcp, 16 KiB | stays inline |
| tcp, 16 KiB + 1 MiB in one message | only the large payload is registered and read |
| `DEFW_RMA_ATTACHMENTS=0`, 1 MiB | inline, over TCP as it exceeds the eager buffer |
| `DEFW_RMA_THRESHOLD=0`, 16 KiB | forced onto RMA |
| sm2 (offers no RMA), 1 MiB | falls back to inline |
| existing mpi smoke test | passes, on both providers |

The routing decision is additionally covered by a standalone test against a
stubbed C layer, since it needs neither libfabric nor a peer.

## Not included

- Memory-registration caching. `fi_mr_reg` is inexpensive on the tcp provider,
  so this only pays off on a NIC provider and is better decided with phase 2
  measurements in hand.
- Adopting attachments in a bulk-data service path as the proving case, and the
  large-payload benchmark, which the design document gates on Slingshot.
- Zero-copy publishing. A payload is currently copied twice, once to bytes and
  once into the registered region. The non-copying registration helper exists;
  using it needs a buffer-protocol typemap and keeping the Python object alive
  until the acknowledgement.

The design document in openQSE/QFw predates the implementation and differs from
it in several places (the descriptor's addressing, the receiver registering its
buffer, MR caching, attachments as an explicit argument, and streaming on the
TCP path). It needs a follow-up pass.
